### PR TITLE
Fix cancel for iOS 8.4

### DIFF
--- a/PSOperations/BlockOperation.swift
+++ b/PSOperations/BlockOperation.swift
@@ -39,17 +39,10 @@ public class BlockOperation: Operation {
     */
     public convenience init(mainQueueBlock: dispatch_block_t) {
         self.init(block: { continuation in
-            
-            let semaphore = dispatch_semaphore_create(0)
-            
             dispatch_async(dispatch_get_main_queue()) {
                 mainQueueBlock()
                 continuation()
-                
-                dispatch_semaphore_signal(semaphore)
             }
-            
-            dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)
         })
     }
     

--- a/PSOperations/DelayOperation.swift
+++ b/PSOperations/DelayOperation.swift
@@ -60,20 +60,14 @@ public class DelayOperation: Operation {
             finish()
             return
         }
-
-        let semaphore = dispatch_semaphore_create(0)
         
         let when = dispatch_time(DISPATCH_TIME_NOW, Int64(interval * Double(NSEC_PER_SEC)))
         dispatch_after(when, dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)) {
-            dispatch_semaphore_signal(semaphore)
-            
             // If we were cancelled, then finish() has already been called.
             if !self.cancelled {
                 self.finish()
             }
         }
-        
-        dispatch_semaphore_wait(semaphore, when)
     }
     
     override public func cancel() {

--- a/PSOperations/DelayOperation.swift
+++ b/PSOperations/DelayOperation.swift
@@ -69,10 +69,4 @@ public class DelayOperation: Operation {
             }
         }
     }
-    
-    override public func cancel() {
-        super.cancel()
-        // Cancelling the operation means we don't want to wait anymore.
-        self.finish()
-    }
 }


### PR DESCRIPTION
A complicated bug involving NSOperation, iOS 8.4, cancel() and isFinished (and maybe swift bridging) can sometimes prevent cancel from working, to overcome this I am adding a custom cancel state.