### PR TITLE
Added Podspec file

### DIFF
--- a/PSOperations.podspec
+++ b/PSOperations.podspec
@@ -1,0 +1,39 @@
+Pod::Spec.new do |s|
+
+	s.name         	= "PSOperations"
+	s.version      	= "0.0.1"
+	s.summary      	= "This is an adaptation of the sample code provided in the Advanced NSOperations session of WWDC 2015"
+	s.description  	= <<-DESC
+	This is an adaptation of the sample code provided in the [Advanced NSOperations session of WWDC 2015](https://developer.apple.com/videos/wwdc/2015/?id=226).  This code has been updated to work with the latest Swift changes as of Xcode 7.  For usage examples, see WWDC 2015 Advanced NSOperations and/or look at the included unit tests.
+
+	Feel free to fork and submit pull requests, as we are always looking for improvements from the community.
+
+	Differences from the first version of the WWDC sample code:
+
+	- Canceling operations would not work.
+	- Canceling functions are slightly more friendly.
+	- Negated Condition would not negate.
+	- Unit tests!
+	
+	Differences from the second version of the WWDC sample code:
+
+	- Sometimes canceling wouldn't work correctly in iOS 8.4. The finished override wasn't being called during cancel. We have fixed this to work in both iOS 8.4 and iOS 9.0.
+	- Canceling functions are slightly more friendly.
+	- Unit tests!
+	
+	A difference from the WWDC Sample code worth mentioning:
+
+	- When conditions are evaluated and they fail the associated operation is cancelled. The operation still goes through the same flow otherwise, only now it will be marked as cancelled.
+
+	DESC
+
+	s.homepage	= "https://github.com/pluralsight/PSOperations"
+	s.license	= { :type => 'MIT' }
+	s.author	= "Matt McMurrym", "Mark Schultz"
+	s.platform     	= :ios, '8.0'
+
+	s.requires_arc = true
+
+	s.source 	= {  git: "https://github.com/pluralsight/PSOperations.git",  tag: s.version.to_s  }
+	s.source_files = 'PSOperations/**/*.swift'
+end

--- a/PSOperations.podspec
+++ b/PSOperations.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
 
 	s.homepage	= "https://github.com/pluralsight/PSOperations"
 	s.license	= { :type => 'MIT' }
-	s.author	= "Matt McMurrym", "Mark Schultz"
+	s.author	= "Matt McMurry", "Mark Schultz"
 	s.platform     	= :ios, '8.0'
 
 	s.requires_arc = true


### PR DESCRIPTION
First, let me say Thank You!  I love the concept; my dev team had thought to do the same thing.

Would you consider making it a **Cocoapod** and/or allowing for **Carthage** integration?

For **Cocoapod** ask, I'm including a candidate for a podspec, which should you guys approve, would only require you to tag and then publish via [cocoapods.org](https://cocoapods.org/). The pod spec *should* be ready to go, but again you'd need to tag... which brings me to my next ask:  
**Carthage**. I believe all you need to do is tag your repo so that Carthage has something to pull against. (I'm still new to the Carthage scene).  

If I'm totally off base, I apologize.  Thanks again!