### PR TITLE
Updates podspec to support tvOS

### DIFF
--- a/PSOperations.podspec
+++ b/PSOperations.podspec
@@ -30,7 +30,8 @@ Pod::Spec.new do |s|
 	s.homepage	= "https://github.com/pluralsight/PSOperations"
 	s.license	= { :type => 'MIT' }
 	s.author	= "Matt McMurry", "Mark Schultz"
-	s.platform     	= :ios, '8.0'
+    s.ios.deployment_target = '8.0'
+    s.tvos.deployment_target = '9.0'
 
 	s.requires_arc = true
 

--- a/PSOperations.podspec
+++ b/PSOperations.podspec
@@ -35,6 +35,6 @@ Pod::Spec.new do |s|
 
 	s.requires_arc = true
 
-	s.source 	= {  git: "https://github.com/pluralsight/PSOperations.git",  tag: s.version.to_s  }
+    s.source 	= {  git: "https://github.com/pluralsight/PSOperations.git" }#,  commit: s.version.to_s  }
 	s.source_files = 'PSOperations/**/*.swift'
 end


### PR DESCRIPTION
This pull request adds tvOS support to the podspec. It also works around an issue found by `pod spec lint`, which was that the '0.0.1' tag could not be found. For now I've gotten around it by commenting out the specification of a tag in the podspec; a longer term fix will be to tag a commit as 0.0.1 and update the podspec accordingly.

The podspec still does not pass lint, but I think that's a bug in CocoaPods' tvOS support because I was able to use it with a tvOS target and the target built successfully.

(I'm using CocoaPods 0.39.0 beta 5.)