### PR TITLE
Added targets: iOS, watchOS and OS X as per #16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ DerivedData
 # Carthage/Checkouts
 
 Carthage/Build
+.DS_Store

--- a/PSOperations.podspec
+++ b/PSOperations.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         	= "PSOperations"
-	s.version      	= "0.0.1"
+	s.version      	= "2.0"
 	s.summary      	= "This is an adaptation of the sample code provided in the Advanced NSOperations session of WWDC 2015"
 	s.description  	= <<-DESC
 	This is an adaptation of the sample code provided in the [Advanced NSOperations session of WWDC 2015](https://developer.apple.com/videos/wwdc/2015/?id=226).  This code has been updated to work with the latest Swift changes as of Xcode 7.  For usage examples, see WWDC 2015 Advanced NSOperations and/or look at the included unit tests.
@@ -30,7 +30,10 @@ Pod::Spec.new do |s|
 	s.homepage	= "https://github.com/pluralsight/PSOperations"
 	s.license	= { :type => 'MIT' }
 	s.author	= "Matt McMurry", "Mark Schultz"
-	s.platform     	= :ios, '8.0'
+
+	s.ios.deployment_target = '8.0'
+	s.watchos.deployment_target = "2.0"
+	s.osx.deployment_target = "10.11"
 
 	s.requires_arc = true
 


### PR DESCRIPTION
Left out tvOS as it's in beta.  It could be added in a beta branch, if that's the route you want to go.