### PR TITLE
Make AlertPresentation public

### DIFF
--- a/PSOperations/MutuallyExclusive.swift
+++ b/PSOperations/MutuallyExclusive.swift
@@ -33,7 +33,7 @@ public struct MutuallyExclusive<T>: OperationCondition {
     The purpose of this enum is to simply provide a non-constructible
     type to be used with `MutuallyExclusive<T>`.
 */
-enum Alert { }
+public enum Alert { }
 
 /// A condition describing that the targeted operation may present an alert.
-typealias AlertPresentation = MutuallyExclusive<Alert>
+public typealias AlertPresentation = MutuallyExclusive<Alert>


### PR DESCRIPTION
This is to follow up on #21.

@MarkQSchultz: Actually, I'm not using it in any of my projects right now. I was just going through the code and think it is likely anyone integrating PSOperations via Cocoapods and writing their own operations may also wish to make their alerts mutually exclusive to the alerts generated by the various PSOperation operations.

Wow. That was a mouth full. Hope I got the point across.