### PR TITLE
make state property public, remove a no-need func

### DIFF
--- a/PSOperations/Operation.swift
+++ b/PSOperations/Operation.swift
@@ -35,7 +35,7 @@ public class Operation: NSOperation {
     
     // MARK: State Management
     
-    private enum State: Int, Comparable {
+    public enum State: Int, Comparable {
         /// The initial state of an `Operation`.
         case Initialized
         
@@ -63,7 +63,7 @@ public class Operation: NSOperation {
         /// The `Operation` has finished executing.
         case Finished
         
-        func canTransitionToState(target: State, operationIsCancelled cancelled: Bool) -> Bool {
+        private func canTransitionToState(target: State, operationIsCancelled cancelled: Bool) -> Bool {
             switch (self, target) {
             case (.Initialized, .Pending):
                 return true
@@ -103,7 +103,7 @@ public class Operation: NSOperation {
     /// A lock to guard reads and writes to the `_state` property
     private let stateLock = NSLock()
 
-    private var state: State {
+    public var state: State {
         get {
             return stateLock.withCriticalScope {
                 _state
@@ -380,10 +380,6 @@ public class Operation: NSOperation {
 }
 
 // Simple operator functions to simplify the assertions used above.
-private func <(lhs: Operation.State, rhs: Operation.State) -> Bool {
+public func <(lhs: Operation.State, rhs: Operation.State) -> Bool {
     return lhs.rawValue < rhs.rawValue
-}
-
-private func ==(lhs: Operation.State, rhs: Operation.State) -> Bool {
-    return lhs.rawValue == rhs.rawValue
 }


### PR DESCRIPTION
I think it is better to expose the state property to public, because to find out whether an operation is adding to an operationQueue is very easy with the state property, while if the state property is private, it is hard to figure out whether an operation is added to an operationQueue.

the == func for Operation.State is not need, since the enum type is Equatable