### PR TITLE
Make the OperationConditionKey public

### DIFF
--- a/PSOperations/OperationCondition.swift
+++ b/PSOperations/OperationCondition.swift
@@ -8,7 +8,7 @@ This file contains the fundamental logic relating to Operation conditions.
 
 import Foundation
 
-let OperationConditionKey = "OperationCondition"
+public let OperationConditionKey = "OperationCondition"
 
 /**
     A protocol for defining conditions that must be satisfied in order for an

--- a/PSOperations/OperationErrors.swift
+++ b/PSOperations/OperationErrors.swift
@@ -8,7 +8,7 @@ This file defines the error codes and convenience functions for interacting with
 
 import Foundation
 
-let OperationErrorDomain = "OperationErrors"
+public let OperationErrorDomain = "OperationErrors"
 
 public enum OperationErrorCode: Int {
     case ConditionFailed = 1

--- a/PSOperations/ReachabilityCondition.swift
+++ b/PSOperations/ReachabilityCondition.swift
@@ -17,7 +17,7 @@ import SystemConfiguration
     Reachability is evaluated once when the operation to which this is attached is asked about its readiness.
 */
 public struct ReachabilityCondition: OperationCondition {
-    static let hostKey = "Host"
+    public static let hostKey = "Host"
     public static let name = "Reachability"
     public static let isMutuallyExclusive = false
     


### PR DESCRIPTION
It's all very well using it to create errors, but making the key public
means that clients of the framework can use it to get values out of the
dictionary as well.