### PR TITLE
Have ready logic be locked with a recursive lock for events where...

### DIFF
--- a/PSOperations/NSLock+Operations.swift
+++ b/PSOperations/NSLock+Operations.swift
@@ -16,3 +16,12 @@ extension NSLock {
         return value
     }
 }
+
+extension NSRecursiveLock {
+    func withCriticalScope<T>(@noescape block: Void -> T) -> T {
+        lock()
+        let value = block()
+        unlock()
+        return value
+    }
+}


### PR DESCRIPTION
multiple threads check readiness at the same time. The recursive lock allows the same thread to check ready again. This is because the ready property has side effects that may cause ready to be recursively called. Unfortunately writing tests for this is difficult.