### PR TITLE
Add a cancellation callback to OperationObserver

### DIFF
--- a/PSOperations/BlockObserver.swift
+++ b/PSOperations/BlockObserver.swift
@@ -16,11 +16,13 @@ public struct BlockObserver: OperationObserver {
     // MARK: Properties
     
     private let startHandler: (Operation -> Void)?
+    private let cancelHandler: (Operation -> Void)?
     private let produceHandler: ((Operation, NSOperation) -> Void)?
     private let finishHandler: ((Operation, [NSError]) -> Void)?
     
-    public init(startHandler: (Operation -> Void)? = nil, produceHandler: ((Operation, NSOperation) -> Void)? = nil, finishHandler: ((Operation, [NSError]) -> Void)? = nil) {
+    public init(startHandler: (Operation -> Void)? = nil, cancelHandler: (Operation -> Void)? = nil, produceHandler: ((Operation, NSOperation) -> Void)? = nil, finishHandler: ((Operation, [NSError]) -> Void)? = nil) {
         self.startHandler = startHandler
+        self.cancelHandler = cancelHandler
         self.produceHandler = produceHandler
         self.finishHandler = finishHandler
     }
@@ -29,6 +31,10 @@ public struct BlockObserver: OperationObserver {
     
     public func operationDidStart(operation: Operation) {
         startHandler?(operation)
+    }
+    
+    public func operationDidCancel(operation: Operation) {
+        cancelHandler?(operation)
     }
     
     public func operation(operation: Operation, didProduceOperation newOperation: NSOperation) {

--- a/PSOperations/LocationOperation.swift
+++ b/PSOperations/LocationOperation.swift
@@ -32,6 +32,11 @@ public class LocationOperation: Operation, CLLocationManagerDelegate {
         super.init()
         addCondition(LocationCondition(usage: .WhenInUse))
         addCondition(MutuallyExclusive<CLLocationManager>())
+        addObserver(BlockObserver(cancelHandler: { [weak self] _ in
+            dispatch_async(dispatch_get_main_queue()) {
+                self?.stopLocationUpdates()
+            }
+        }))
     }
     
     override public func execute() {
@@ -53,13 +58,6 @@ public class LocationOperation: Operation, CLLocationManagerDelegate {
             }
             
             self.manager = manager
-        }
-    }
-    
-    override public func cancel() {
-        dispatch_async(dispatch_get_main_queue()) {
-            self.stopLocationUpdates()
-            super.cancel()
         }
     }
     

--- a/PSOperations/Operation.swift
+++ b/PSOperations/Operation.swift
@@ -203,6 +203,13 @@ public class Operation: NSOperation {
         
         didSet {
             didChangeValueForKey("cancelledState")
+            if _cancelled != oldValue && _cancelled == true {
+                
+                for observer in observers {
+                    observer.operationDidCancel(self)
+                }
+                
+            }
         }
     }
     

--- a/PSOperations/OperationObserver.swift
+++ b/PSOperations/OperationObserver.swift
@@ -17,6 +17,9 @@ public protocol OperationObserver {
     /// Invoked immediately prior to the `Operation`'s `execute()` method.
     func operationDidStart(operation: Operation)
     
+    /// Invoked immediately after the first time the `Operation`'s `cancel()` method is called
+    func operationDidCancel(operation: Operation)
+    
     /// Invoked when `Operation.produceOperation(_:)` is executed.
     func operation(operation: Operation, didProduceOperation newOperation: NSOperation)
     

--- a/PSOperations/TimeoutObserver.swift
+++ b/PSOperations/TimeoutObserver.swift
@@ -45,6 +45,10 @@ public struct TimeoutObserver: OperationObserver {
             }
         }
     }
+    
+    public func operationDidCancel(operation: Operation) {
+        // No op.
+    }
 
     public func operation(operation: Operation, didProduceOperation newOperation: NSOperation) {
         // No op.

--- a/PSOperations/URLSessionTaskOperation.swift
+++ b/PSOperations/URLSessionTaskOperation.swift
@@ -31,6 +31,10 @@ public class URLSessionTaskOperation: Operation {
         assert(task.state == .Suspended, "Tasks must be suspended.")
         self.task = task
         super.init()
+        
+        addObserver(BlockObserver(cancelHandler: { _ in
+            task.cancel()
+        }))
     }
     
     override public func execute() {
@@ -58,10 +62,5 @@ public class URLSessionTaskOperation: Operation {
                 }
             }
         }
-    }
-    
-    override public func cancel() {
-        task.cancel()
-        super.cancel()
     }
 }

--- a/PSOperationsTests/PSOperationsTests.swift
+++ b/PSOperationsTests/PSOperationsTests.swift
@@ -51,6 +51,10 @@ class TestObserver: OperationObserver {
         
     }
     
+    func operationDidCancel(operation: Operation) {
+        
+    }
+    
     func operationDidFinish(operation: Operation, errors: [NSError]) {
         finished = true
         self.errors = errors


### PR DESCRIPTION
This makes it much easier for an `Operation` subclass to react to cancellation. If you were to override `cancel()`, you'd have to account for the possibility that the method may be called multiple times. By using a cancellation observer, you don't.