### PR TITLE
GroupOperation incorrectly notifies subclass of finish of internal startingOperation

### DIFF
--- a/PSOperations/GroupOperation.swift
+++ b/PSOperations/GroupOperation.swift
@@ -106,7 +106,7 @@ extension GroupOperation: OperationQueueDelegate {
             internalQueue.suspended = true
             finish(aggregatedErrors)
         }
-        else {
+        else if operation !== startingOperation {
             operationDidFinish(operation, withErrors: errors)
         }
     }


### PR DESCRIPTION
Currently, if you subclass GroupOperation and override `operationDidFinish`, you are notified of the super class' private `startingOperation` finish. This is an internal implementation detail that the subclasser should **not** be notified of. 

Note: this condition **does** exist in the sample AdvancedNSOperations project so I am not sure if this is purposefully removed in PSOperations or how it diverged. 