### PR TITLE
Add public initializers to public structs

### DIFF
--- a/PSOperations/LocationCapability-OSX.swift
+++ b/PSOperations/LocationCapability-OSX.swift
@@ -13,6 +13,8 @@ import CoreLocation
 
 public struct Location: CapabilityType {
     public static let name = "Location"
+
+    public init() { }
     
     public func requestStatus(completion: CapabilityStatus -> Void) {
         guard CLLocationManager.locationServicesEnabled() else {

--- a/PSOperations/LocationCapability-tvOS.swift
+++ b/PSOperations/LocationCapability-tvOS.swift
@@ -13,7 +13,9 @@ import CoreLocation
 
 public struct Location: CapabilityType {
     public static let name = "Location"
-    
+
+    public init() { }
+
     public func requestStatus(completion: CapabilityStatus -> Void) {
         guard CLLocationManager.locationServicesEnabled() else {
             completion(.NotAvailable)

--- a/PSOperations/PhotosCapability.swift
+++ b/PSOperations/PhotosCapability.swift
@@ -13,6 +13,8 @@ import Photos
 
 public struct Photos: CapabilityType {
     public static let name = "Photos"
+
+    public init() { }
     
     public func requestStatus(completion: CapabilityStatus -> Void) {
         let status = PHPhotoLibrary.authorizationStatus()

--- a/PSOperations/PushCapability-iOS.swift
+++ b/PSOperations/PushCapability-iOS.swift
@@ -21,6 +21,8 @@ public struct Push: CapabilityType {
     }
 
     public static let name = "Push"
+
+    public init() { }
     
     public func requestStatus(completion: CapabilityStatus -> Void) {
         if let _ = authorizer.token {


### PR DESCRIPTION
Hi there! When importing the project via CocoaPods, we found that we were unable to initialize several structs because the default initializers are internal by default. This PR adds a public, no-argument initializer to all public structs in the project which were using the default initializer.

From [the docs](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/AccessControl.html):
> For a type that is defined as public, the default initializer is considered internal. If you want a public type to be initializable with a no-argument initializer when used in another module, you must explicitly provide a public no-argument initializer yourself as part of the type’s definition.
