### PR TITLE
Split podspec into subspecs to handle usage of non-primary frameworks

### DIFF
--- a/PSOperations.podspec
+++ b/PSOperations.podspec
@@ -36,6 +36,7 @@ Pod::Spec.new do |s|
 	s.osx.deployment_target = "10.11"
 
 	s.requires_arc = true
+	s.pod_target_xcconfig = { "EMBEDDED_CONTENT_CONTAINS_SWIFT" => "YES" }
 
 	s.source 	= {  git: "https://github.com/pluralsight/PSOperations.git",  tag: s.version.to_s  }
 	

--- a/PSOperations.podspec
+++ b/PSOperations.podspec
@@ -38,5 +38,55 @@ Pod::Spec.new do |s|
 	s.requires_arc = true
 
 	s.source 	= {  git: "https://github.com/pluralsight/PSOperations.git",  tag: s.version.to_s  }
-	s.source_files = 'PSOperations/**/*.swift'
+	
+	subspec_sources = { 
+		"CloudKit" => [
+			"PSOperations/iCloudContainerCapability.swift", 
+			"PSOperations/CloudCondition.swift",
+			"PSOperations/CKContainer+Operations.swift",
+			"CloudCondition.swift"
+		],
+		"HealthKit" => ["PSOperations/Health*.swift"],
+		"CoreLocation" => ["PSOperations/Location*.swift"],
+		"PassKit" => ["PSOperations/Passbook*.swift"],
+		"Photos" => ["PSOperations/Photos*.swift"],
+		"SystemConfiguration" => ["PSOperations/ReachabilityCondition.swift"],
+		"EventKit" => ["PSOperations/Calendar*.swift"]
+		}
+	
+	s.source_files = "PSOperations/**/*.swift"
+	s.exclude_files = subspec_sources.values.flatten()
+
+	s.subspec "Core" do |sb|
+		sb.source_files = "PSOperations/**/*.swift"
+		sb.exclude_files = subspec_sources.values.flatten()
+	end
+
+	s.subspec "CloudKit" do |sb|
+		sb.source_files = subspec_sources["CloudKit"]
+	end
+
+	s.subspec "HealthKit" do |sb|
+		sb.source_files = subspec_sources["HealthKit"]
+	end
+
+	s.subspec "CoreLocation" do |sb|
+		sb.source_files = subspec_sources["CoreLocation"]
+	end
+
+	s.subspec "PassKit" do |sb|
+		sb.source_files = subspec_sources["PassKit"]
+	end
+
+	s.subspec "Photos" do |sb|
+		sb.source_files = subspec_sources["Photos"]
+	end
+
+	s.subspec "SystemConfiguration" do |sb|
+		sb.source_files = subspec_sources["SystemConfiguration"]
+	end
+
+	s.subspec "EventKit" do |sb|
+		sb.source_files = subspec_sources["EventKit"]
+	end
 end


### PR DESCRIPTION
Hi all,

We had some issues pulling in this library using the existing podspec: there is currently no way to deselect operations related to non-primary system frameworks such as HealthKit, Photos, PassKit. In order to tackle this, I used pod subspecs. This leaves the default spec unchanged (use everything), but adds a `Core` subspec that just links "primary" framework-related features, and named subspecs for the features that relate to the additional frameworks.

Also, seemed to need to add `EMBEDDED_CONTENT_CONTAINS_SWIFT` for our use, otherwise linker issues such as:

```
dyld: Library not loaded: @rpath/libswiftCloudKit.dylib
  Referenced from: /Users/jc/Library/Developer/Xcode/DerivedData/TheRoll-hctojcossehvaiexpbpikunlwypw/Build/Products/Debug-iphonesimulator/PSOperations.framework/PSOperations
  Reason: image not found
```

Should resolve #34 

Please let me know what you think.

Thanks!