### PR TITLE
Make convenience extensions public

### DIFF
--- a/PSOperations/Dictionary+Operations.swift
+++ b/PSOperations/Dictionary+Operations.swift
@@ -6,7 +6,7 @@ Abstract:
 A convenient extension to Swift.Dictionary.
 */
 
-extension Dictionary {
+public extension Dictionary {
     /**
         It's not uncommon to want to turn a sequence of values into a dictionary,
         where each value is keyed by some unique identifier. This initializer will

--- a/PSOperations/NSLock+Operations.swift
+++ b/PSOperations/NSLock+Operations.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension NSLock {
+public extension NSLock {
     func withCriticalScope<T>(@noescape block: Void -> T) -> T {
         lock()
         let value = block()
@@ -17,7 +17,7 @@ extension NSLock {
     }
 }
 
-extension NSRecursiveLock {
+public extension NSRecursiveLock {
     func withCriticalScope<T>(@noescape block: Void -> T) -> T {
         lock()
         let value = block()

--- a/PSOperations/NSOperation+Operations.swift
+++ b/PSOperations/NSOperation+Operations.swift
@@ -8,7 +8,7 @@ A convenient extension to Foundation.NSOperation.
 
 import Foundation
 
-extension NSOperation {
+public extension NSOperation {
     /** 
         Add a completion block to be executed after the `NSOperation` enters the
         "finished" state.

--- a/PSOperations/UIUserNotifications+Operations.swift
+++ b/PSOperations/UIUserNotifications+Operations.swift
@@ -10,7 +10,7 @@ A convenient extension to UIKit.UIUserNotificationSettings.
 
 import UIKit
 
-extension UIUserNotificationSettings {
+public extension UIUserNotificationSettings {
     /// Check to see if one Settings object is a superset of another Settings object.
     func contains(settings: UIUserNotificationSettings) -> Bool {
         // our types must contain all of the other types


### PR DESCRIPTION
Hi all,

These extensions are currently `internal`, but are quite handy and could/should be `public`. The `NSLock` extensions, in particular, would be nice to expose, even though they are *reasonably* trivial.

In any case, please let me know what you think.