### PR TITLE
Error management during `cancel` & `finish`

### DIFF
--- a/PSOperations/Operation.swift
+++ b/PSOperations/Operation.swift
@@ -322,6 +322,12 @@ public class Operation: NSOperation {
     }
     
     private var _internalErrors = [NSError]()
+  
+  
+    public var errors : [NSError] {
+        return _internalErrors
+    }
+  
     override public func cancel() {
         if finished {
             return
@@ -378,11 +384,12 @@ public class Operation: NSOperation {
             hasFinishedAlready = true
             state = .Finishing
             
-            let combinedErrors = _internalErrors + errors
-            finished(combinedErrors)
+            _internalErrors += errors
+          
+            finished(_internalErrors)
             
             for observer in observers {
-                observer.operationDidFinish(self, errors: combinedErrors)
+                observer.operationDidFinish(self, errors: _internalErrors)
             }
             
             state = .Finished

--- a/PSOperationsTests/PSOperationsTests.swift
+++ b/PSOperationsTests/PSOperationsTests.swift
@@ -1056,4 +1056,59 @@ class PSOperationsTests: XCTestCase {
             XCTAssertEqual(opCount, requiredToPassCount)
         }
     }
+    
+    func testOperationFinishedWithErrors() {
+        let opQ = OperationQueue()
+        
+        class ErrorOp : Operation {
+            
+            let sema = dispatch_semaphore_create(0)
+            
+            override func execute() {
+                finishWithError(NSError(code: .ExecutionFailed))
+            }
+            
+            override func finished(errors: [NSError]) {
+                dispatch_semaphore_signal(sema)
+            }
+            
+            override func waitUntilFinished() {
+                dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER)
+            }
+        }
+        
+        let op = ErrorOp()
+        
+        opQ.addOperations([op], waitUntilFinished: true)
+        
+        XCTAssertEqual(op.errors, [NSError(code: .ExecutionFailed)])
+    }
+    
+    func testOperationCancelledWithErrors() {
+        let opQ = OperationQueue()
+        
+        class ErrorOp : Operation {
+            
+            let sema = dispatch_semaphore_create(0)
+            
+            override func execute() {
+                cancelWithError(NSError(code: .ExecutionFailed))
+            }
+            
+            override func finished(errors: [NSError]) {
+                dispatch_semaphore_signal(sema)
+            }
+            
+            override func waitUntilFinished() {
+                dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER)
+            }
+        }
+        
+        let op = ErrorOp()
+        
+        opQ.addOperations([op], waitUntilFinished: true)
+        
+        XCTAssertEqual(op.errors, [NSError(code: .ExecutionFailed)])
+    }
+    
 }


### PR DESCRIPTION
Previously errors passed to finish or finishWithError were not saved for later retrieval; now they are. Also, exposed a new read-only `errors` property to access the errors that were passed to `finish` or `cancel`