### PR TITLE
Change out complex solution to simple solution to prevent cascading dependency crashes.

### DIFF
--- a/PSOperations/OperationQueue.swift
+++ b/PSOperations/OperationQueue.swift
@@ -47,6 +47,8 @@ public class OperationQueue: NSOperationQueue {
                     if let q = self {
                         
                         q.delegate?.operationQueue?(q, operationDidFinish: finishedOperation, withErrors: errors)
+                        //Remove deps to avoid cascading deallocation error
+                        //http://stackoverflow.com/questions/19693079/nsoperationqueue-bug-with-dependencies
                         finishedOperation.dependencies.forEach { finishedOperation.removeDependency($0) }
                     }
                 }
@@ -95,6 +97,8 @@ public class OperationQueue: NSOperationQueue {
             operation.addCompletionBlock { [weak self, weak operation] in
                 guard let queue = self, let operation = operation else { return }
                 queue.delegate?.operationQueue?(queue, operationDidFinish: operation, withErrors: [])
+                //Remove deps to avoid cascading deallocation error
+                //http://stackoverflow.com/questions/19693079/nsoperationqueue-bug-with-dependencies
                 operation.dependencies.forEach { operation.removeDependency($0) }
             }
         }


### PR DESCRIPTION
Quick Review: There appears to be a bug with NSObject where sometimes when the parent object of long list of dependent objects deallocates, the cascading deallocation sometimes crashes.

I've come up with a simpler way to handle the issue and want feedback on pros and cons. 