### PR TITLE
Revisions to README for subspecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ PSOperations supports multiple methods for installing the library in a project.
 $ gem install cocoapods
 ```
 
-To integrate PSOperations into your Xcode project using CocoaPods, specify it in your `Podfile`:
+To integrate PSOperations into your Xcode project using CocoaPods, specify it in your `Podfile`.  
+If you want all the children ‘sub-specifications’, including Health and Pass Capabilities:
 
 ```ruby
 source 'https://github.com/CocoaPods/Specs.git'
@@ -41,14 +42,9 @@ pod 'PSOperations', '~> 2.3'
 end
 ```
 
-If you want to use Health Capabilities:
+If you only want core functionality, _omitting_ the capabilities mentioned above:
 ```ruby
-pod 'PSOperations/Health', '~> 2.3'
-```
-
-if you want to use Pass Capabilities:
-```ruby
-pod 'PSOperations/Passbook', '~> 2.3'
+pod 'PSOperations/Core', '~> 2.3'
 ```
 
 Then, run the following command:

--- a/README.md
+++ b/README.md
@@ -42,15 +42,26 @@ pod 'PSOperations', '~> 2.3'
 end
 ```
 
-If you only want core functionality, _omitting_ the capabilities mentioned above:
-```ruby
-pod 'PSOperations/Core', '~> 2.3'
-```
-
 Then, run the following command:
 
 ```bash
 $ pod install
+```
+
+**Alternative configurations:**
+Core functionality, _excluding_ capabilities:
+```ruby
+pod 'PSOperations/Core', '~> 2.3'
+```
+
+Core functionality, including only the Passbook capability:
+```ruby
+pod 'PSOperations/Passbook', '~> 2.3'
+```
+
+Core functionality, including only the Health capability:
+```ruby
+pod 'PSOperations/Health', '~> 2.3'
 ```
 
 ###Carthage

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ gem install cocoapods
 ```
 
 To integrate PSOperations into your Xcode project using CocoaPods, specify it in your `Podfile`.  
-If you want all the children ‘sub-specifications’, including Health and Pass Capabilities:
+If you want all the child subspecs (Health and Passbook capabilities):
 
 ```ruby
 source 'https://github.com/CocoaPods/Specs.git'
@@ -48,7 +48,7 @@ Then, run the following command:
 $ pod install
 ```
 
-**Alternative configurations:**
+**Alternative configurations:**  
 Core functionality, _excluding_ capabilities:
 ```ruby
 pod 'PSOperations/Core', '~> 2.3'


### PR DESCRIPTION
Makes clear how to avoid including HealthKit and Pass capabilities, which can cause app store rejections if included and not used.