### PR TITLE
Swift 3.0 migration

### DIFF
--- a/PSOperations.podspec
+++ b/PSOperations.podspec
@@ -1,30 +1,12 @@
 Pod::Spec.new do |s|
 
 	s.name         	= "PSOperations"
-	s.version      	= "2.2.0"
+	s.version      	= "2.3.0"
 	s.summary      	= "This is an adaptation of the sample code provided in the Advanced NSOperations session of WWDC 2015"
 	s.description  	= <<-DESC
-	This is an adaptation of the sample code provided in the [Advanced NSOperations session of WWDC 2015](https://developer.apple.com/videos/wwdc/2015/?id=226).  This code has been updated to work with the latest Swift changes as of Xcode 7.  For usage examples, see WWDC 2015 Advanced NSOperations and/or look at the included unit tests.
+	PSOperations is a framework that leverages the power of NSOperation and NSOperationQueue. It enables you to use operations more easily in all parts of your project.
 
-	Feel free to fork and submit pull requests, as we are always looking for improvements from the community.
-
-	Differences from the first version of the WWDC sample code:
-
-	- Canceling operations would not work.
-	- Canceling functions are slightly more friendly.
-	- Negated Condition would not negate.
-	- Unit tests!
-	
-	Differences from the second version of the WWDC sample code:
-
-	- Sometimes canceling wouldn't work correctly in iOS 8.4. The finished override wasn't being called during cancel. We have fixed this to work in both iOS 8.4 and iOS 9.0.
-	- Canceling functions are slightly more friendly.
-	- Unit tests!
-	
-	A difference from the WWDC Sample code worth mentioning:
-
-	- When conditions are evaluated and they fail the associated operation is cancelled. The operation still goes through the same flow otherwise, only now it will be marked as cancelled.
-
+	This is an adaptation of the sample code provided in the [Advanced NSOperations session of WWDC 2015](https://developer.apple.com/videos/wwdc/2015/?id=226).
 	DESC
 
 	s.homepage	= "https://github.com/pluralsight/PSOperations"
@@ -34,9 +16,18 @@ Pod::Spec.new do |s|
 	s.ios.deployment_target = '8.0'
 	s.watchos.deployment_target = "2.0"
 	s.osx.deployment_target = "10.11"
+	s.tvos.deployment_target = "9.0"
 
 	s.requires_arc = true
 
 	s.source 	= {  git: "https://github.com/pluralsight/PSOperations.git",  tag: s.version.to_s  }
 	s.source_files = 'PSOperations/**/*.swift'
+
+	subspec 'PSOperationsHealth' do |health|
+  		health.source_files = 'PSOperationsHealth/**/*.swift'
+	end
+
+	subspec 'PSOperationsPassbook do |passbook|
+		passbook.source_files = 'PSOperationsPassbook/**/*.swift'
+	end
 end

--- a/PSOperations.podspec
+++ b/PSOperations.podspec
@@ -20,14 +20,22 @@ Pod::Spec.new do |s|
 
 	s.requires_arc = true
 
-	s.source 	= {  git: "https://github.com/pluralsight/PSOperations.git",  tag: s.version.to_s  }
-	s.source_files = 'PSOperations/**/*.swift'
+	s.source = {  git: "https://github.com/pluralsight/PSOperations.git",  tag: s.version.to_s  }
+	
+	s.source_files = "PSOperations/*.swift"
 
-	subspec 'Health' do |health|
-  		health.source_files = 'PSOperationsHealth/**/*.swift'
-	end
-
-	subspec 'Passbook do |passbook|
-		passbook.source_files = 'PSOperationsPassbook/**/*.swift'
-	end
+  	s.subspec "Core" do |sb|
+  		sb.source_files = "PSOperations/*.swift"
+  	end
+  
+  	s.subspec "Health" do |sb|
+	  	sb.dependency 'PSOperations/Core'
+  		sb.source_files = "PSOperationsHealth/*.swift"
+  	end
+  
+  	s.subspec "Passbook" do |sb|
+	  	sb.dependency 'PSOperations/Core'
+  		sb.source_files = "PSOperationsPassbook/*.swift"
+  	end
+  
 end

--- a/PSOperations.podspec
+++ b/PSOperations.podspec
@@ -23,11 +23,11 @@ Pod::Spec.new do |s|
 	s.source 	= {  git: "https://github.com/pluralsight/PSOperations.git",  tag: s.version.to_s  }
 	s.source_files = 'PSOperations/**/*.swift'
 
-	subspec 'PSOperationsHealth' do |health|
+	subspec 'Health' do |health|
   		health.source_files = 'PSOperationsHealth/**/*.swift'
 	end
 
-	subspec 'PSOperationsPassbook do |passbook|
+	subspec 'Passbook do |passbook|
 		passbook.source_files = 'PSOperationsPassbook/**/*.swift'
 	end
 end

--- a/PSOperations.xcodeproj/project.pbxproj
+++ b/PSOperations.xcodeproj/project.pbxproj
@@ -552,9 +552,11 @@
 				TargetAttributes = {
 					1D9B430D1B6A92ED008F7F18 = {
 						CreatedOnToolsVersion = 6.4;
+						LastSwiftMigration = 0800;
 					};
 					1D9B43181B6A92ED008F7F18 = {
 						CreatedOnToolsVersion = 6.4;
+						LastSwiftMigration = 0800;
 					};
 					FD19C9CF1C440293005D0F07 = {
 						CreatedOnToolsVersion = 7.2;
@@ -872,6 +874,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -894,6 +897,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -909,6 +913,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos macosx watchsimulator watchos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -921,6 +926,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.pluralsight.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos macosx watchsimulator watchos";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/PSOperations.xcodeproj/project.pbxproj
+++ b/PSOperations.xcodeproj/project.pbxproj
@@ -28,11 +28,9 @@
 		1D9B43591B6A934A008F7F18 /* MutuallyExclusive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B433A1B6A934A008F7F18 /* MutuallyExclusive.swift */; };
 		1D9B435A1B6A934A008F7F18 /* ReachabilityCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B433B1B6A934A008F7F18 /* ReachabilityCondition.swift */; };
 		1D9B435B1B6A934A008F7F18 /* CloudCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B433C1B6A934A008F7F18 /* CloudCondition.swift */; };
-		1D9B435C1B6A934A008F7F18 /* PassbookCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B433D1B6A934A008F7F18 /* PassbookCondition.swift */; };
 		1D9B435D1B6A934A008F7F18 /* LocationCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B433E1B6A934A008F7F18 /* LocationCondition.swift */; };
 		1D9B435E1B6A934A008F7F18 /* CalendarCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B433F1B6A934A008F7F18 /* CalendarCondition.swift */; };
 		1D9B435F1B6A934A008F7F18 /* PhotosCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B43401B6A934A008F7F18 /* PhotosCondition.swift */; };
-		1D9B43601B6A934A008F7F18 /* HealthCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B43411B6A934A008F7F18 /* HealthCondition.swift */; };
 		1D9B43611B6A934A008F7F18 /* RemoteNotificationCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B43421B6A934A008F7F18 /* RemoteNotificationCondition.swift */; };
 		1D9B43621B6A934A008F7F18 /* UserNotificationCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B43431B6A934A008F7F18 /* UserNotificationCondition.swift */; };
 		1D9B43631B6A934A008F7F18 /* Dictionary+Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B43441B6A934A008F7F18 /* Dictionary+Operations.swift */; };
@@ -42,12 +40,10 @@
 		55AE64C41BC172ED0097F4A5 /* Capability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64C31BC172ED0097F4A5 /* Capability.swift */; };
 		55AE64C71BC173100097F4A5 /* CalendarCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64C61BC173100097F4A5 /* CalendarCapability.swift */; };
 		55AE64C91BC1732D0097F4A5 /* PhotosCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64C81BC1732D0097F4A5 /* PhotosCapability.swift */; };
-		55AE64CB1BC173560097F4A5 /* PassbookCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64CA1BC173560097F4A5 /* PassbookCapability.swift */; };
 		55AE64CD1BC1738D0097F4A5 /* LocationCapability-iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64CC1BC1738D0097F4A5 /* LocationCapability-iOS.swift */; };
 		55AE64CF1BC175190097F4A5 /* iCloudContainerCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64CE1BC175190097F4A5 /* iCloudContainerCapability.swift */; };
 		55AE64D21BC180570097F4A5 /* LocationCapability-tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64D11BC180570097F4A5 /* LocationCapability-tvOS.swift */; };
 		55AE64D41BC180650097F4A5 /* LocationCapability-OSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64D31BC180650097F4A5 /* LocationCapability-OSX.swift */; };
-		55AE64D61BC19E330097F4A5 /* HealthCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64D51BC19E330097F4A5 /* HealthCapability.swift */; };
 		55AE64DA1BC1C7430097F4A5 /* PushCapability-iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64D91BC1C7430097F4A5 /* PushCapability-iOS.swift */; };
 		55AE64DC1BC1C7E50097F4A5 /* PushCapability-OSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64DB1BC1C7E50097F4A5 /* PushCapability-OSX.swift */; };
 		55AE64DE1BC1DCF50097F4A5 /* UserNotificationCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64DD1BC1DCF50097F4A5 /* UserNotificationCapability.swift */; };
@@ -58,6 +54,14 @@
 		FD19C9DD1C440293005D0F07 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FD19C9DB1C440293005D0F07 /* LaunchScreen.storyboard */; };
 		FD19C9E81C440293005D0F07 /* PSOperationsAppForTestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD19C9E71C440293005D0F07 /* PSOperationsAppForTestsTests.swift */; };
 		FD39C29E1B8B5F090092008B /* PSOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B436D1B6A942C008F7F18 /* PSOperationsTests.swift */; };
+		FD854FDA1D2D8CAB00162079 /* PSOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D9B43131B6A92ED008F7F18 /* PSOperations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FD85500C1D2D8CC100162079 /* PSOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D9B43131B6A92ED008F7F18 /* PSOperations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FD85501D1D2D8D9800162079 /* PSOperations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D9B430E1B6A92ED008F7F18 /* PSOperations.framework */; };
+		FD85501F1D2D8E0E00162079 /* HealthCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8550191D2D8D3400162079 /* HealthCapability.swift */; };
+		FD8550201D2D8E0E00162079 /* HealthCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD85501A1D2D8D3400162079 /* HealthCondition.swift */; };
+		FD8550211D2D8E2200162079 /* PassbookCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8550151D2D8D1D00162079 /* PassbookCapability.swift */; };
+		FD8550221D2D8E2200162079 /* PassbookCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8550161D2D8D1D00162079 /* PassbookCondition.swift */; };
+		FD8550561D2D90A700162079 /* PSOperations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D9B430E1B6A92ED008F7F18 /* PSOperations.framework */; };
 		FDB1BBBE1B8D67CB00FB9D7A /* NSLock+Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB1BBBD1B8D67CB00FB9D7A /* NSLock+Operations.swift */; };
 		FDB1E8F21BBC2B08006BC157 /* OperationConditionResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB1E8F11BBC2B08006BC157 /* OperationConditionResultTests.swift */; };
 		FDC6C5291BBCDDC9008FB96E /* URLSessionTaskOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC6C5281BBCDDC9008FB96E /* URLSessionTaskOperationTests.swift */; };
@@ -107,11 +111,9 @@
 		1D9B433A1B6A934A008F7F18 /* MutuallyExclusive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutuallyExclusive.swift; sourceTree = "<group>"; };
 		1D9B433B1B6A934A008F7F18 /* ReachabilityCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReachabilityCondition.swift; sourceTree = "<group>"; };
 		1D9B433C1B6A934A008F7F18 /* CloudCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudCondition.swift; sourceTree = "<group>"; };
-		1D9B433D1B6A934A008F7F18 /* PassbookCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PassbookCondition.swift; sourceTree = "<group>"; };
 		1D9B433E1B6A934A008F7F18 /* LocationCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationCondition.swift; sourceTree = "<group>"; };
 		1D9B433F1B6A934A008F7F18 /* CalendarCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalendarCondition.swift; sourceTree = "<group>"; };
 		1D9B43401B6A934A008F7F18 /* PhotosCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotosCondition.swift; sourceTree = "<group>"; };
-		1D9B43411B6A934A008F7F18 /* HealthCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthCondition.swift; sourceTree = "<group>"; };
 		1D9B43421B6A934A008F7F18 /* RemoteNotificationCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteNotificationCondition.swift; sourceTree = "<group>"; };
 		1D9B43431B6A934A008F7F18 /* UserNotificationCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNotificationCondition.swift; sourceTree = "<group>"; };
 		1D9B43441B6A934A008F7F18 /* Dictionary+Operations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Operations.swift"; sourceTree = "<group>"; };
@@ -122,12 +124,10 @@
 		55AE64C31BC172ED0097F4A5 /* Capability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Capability.swift; sourceTree = "<group>"; };
 		55AE64C61BC173100097F4A5 /* CalendarCapability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalendarCapability.swift; sourceTree = "<group>"; };
 		55AE64C81BC1732D0097F4A5 /* PhotosCapability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotosCapability.swift; sourceTree = "<group>"; };
-		55AE64CA1BC173560097F4A5 /* PassbookCapability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PassbookCapability.swift; sourceTree = "<group>"; };
 		55AE64CC1BC1738D0097F4A5 /* LocationCapability-iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LocationCapability-iOS.swift"; sourceTree = "<group>"; };
 		55AE64CE1BC175190097F4A5 /* iCloudContainerCapability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = iCloudContainerCapability.swift; sourceTree = "<group>"; };
 		55AE64D11BC180570097F4A5 /* LocationCapability-tvOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LocationCapability-tvOS.swift"; sourceTree = "<group>"; };
 		55AE64D31BC180650097F4A5 /* LocationCapability-OSX.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LocationCapability-OSX.swift"; sourceTree = "<group>"; };
-		55AE64D51BC19E330097F4A5 /* HealthCapability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthCapability.swift; sourceTree = "<group>"; };
 		55AE64D91BC1C7430097F4A5 /* PushCapability-iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PushCapability-iOS.swift"; sourceTree = "<group>"; };
 		55AE64DB1BC1C7E50097F4A5 /* PushCapability-OSX.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PushCapability-OSX.swift"; sourceTree = "<group>"; };
 		55AE64DD1BC1DCF50097F4A5 /* UserNotificationCapability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNotificationCapability.swift; sourceTree = "<group>"; };
@@ -141,6 +141,12 @@
 		FD19C9E31C440293005D0F07 /* PSOperationsAppForTestsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PSOperationsAppForTestsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD19C9E71C440293005D0F07 /* PSOperationsAppForTestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PSOperationsAppForTestsTests.swift; sourceTree = "<group>"; };
 		FD19C9E91C440293005D0F07 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FD854FDF1D2D8CAB00162079 /* PSOperationsHealth.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PSOperationsHealth.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FD8550111D2D8CC100162079 /* PSOperationsPassbook.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PSOperationsPassbook.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FD8550151D2D8D1D00162079 /* PassbookCapability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PassbookCapability.swift; path = PSOperationsPassbook/PassbookCapability.swift; sourceTree = "<group>"; };
+		FD8550161D2D8D1D00162079 /* PassbookCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PassbookCondition.swift; path = PSOperationsPassbook/PassbookCondition.swift; sourceTree = "<group>"; };
+		FD8550191D2D8D3400162079 /* HealthCapability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HealthCapability.swift; path = PSOperationsHealth/HealthCapability.swift; sourceTree = SOURCE_ROOT; };
+		FD85501A1D2D8D3400162079 /* HealthCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HealthCondition.swift; path = PSOperationsHealth/HealthCondition.swift; sourceTree = SOURCE_ROOT; };
 		FDB1BBBD1B8D67CB00FB9D7A /* NSLock+Operations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSLock+Operations.swift"; sourceTree = "<group>"; };
 		FDB1E8F11BBC2B08006BC157 /* OperationConditionResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperationConditionResultTests.swift; sourceTree = "<group>"; };
 		FDC6C5281BBCDDC9008FB96E /* URLSessionTaskOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionTaskOperationTests.swift; sourceTree = "<group>"; };
@@ -178,6 +184,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FD854FD81D2D8CAB00162079 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FD85501D1D2D8D9800162079 /* PSOperations.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FD85500A1D2D8CC100162079 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FD8550561D2D90A700162079 /* PSOperations.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -185,6 +207,8 @@
 			isa = PBXGroup;
 			children = (
 				1D9B43101B6A92ED008F7F18 /* PSOperations */,
+				FD8550141D2D8CDF00162079 /* PSOperationsPassbook */,
+				FD8550131D2D8CCE00162079 /* PSOperationsHealth */,
 				1D9B431D1B6A92ED008F7F18 /* PSOperationsTests */,
 				FD19C9D11C440293005D0F07 /* PSOperationsAppForTests */,
 				FD19C9E61C440293005D0F07 /* PSOperationsAppForTestsTests */,
@@ -199,6 +223,8 @@
 				1D9B43191B6A92ED008F7F18 /* PSOperationsTests.xctest */,
 				FD19C9D01C440293005D0F07 /* PSOperationsAppForTests.app */,
 				FD19C9E31C440293005D0F07 /* PSOperationsAppForTestsTests.xctest */,
+				FD854FDF1D2D8CAB00162079 /* PSOperationsHealth.framework */,
+				FD8550111D2D8CC100162079 /* PSOperationsPassbook.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -309,12 +335,10 @@
 			children = (
 				55AE64C31BC172ED0097F4A5 /* Capability.swift */,
 				55AE64C61BC173100097F4A5 /* CalendarCapability.swift */,
-				55AE64D51BC19E330097F4A5 /* HealthCapability.swift */,
 				55AE64CE1BC175190097F4A5 /* iCloudContainerCapability.swift */,
 				55AE64CC1BC1738D0097F4A5 /* LocationCapability-iOS.swift */,
 				55AE64D11BC180570097F4A5 /* LocationCapability-tvOS.swift */,
 				55AE64D31BC180650097F4A5 /* LocationCapability-OSX.swift */,
-				55AE64CA1BC173560097F4A5 /* PassbookCapability.swift */,
 				55AE64C81BC1732D0097F4A5 /* PhotosCapability.swift */,
 				55AE64D91BC1C7430097F4A5 /* PushCapability-iOS.swift */,
 				55AE64DB1BC1C7E50097F4A5 /* PushCapability-OSX.swift */,
@@ -328,9 +352,7 @@
 			children = (
 				1D9B433F1B6A934A008F7F18 /* CalendarCondition.swift */,
 				1D9B433C1B6A934A008F7F18 /* CloudCondition.swift */,
-				1D9B43411B6A934A008F7F18 /* HealthCondition.swift */,
 				1D9B433E1B6A934A008F7F18 /* LocationCondition.swift */,
-				1D9B433D1B6A934A008F7F18 /* PassbookCondition.swift */,
 				1D9B43401B6A934A008F7F18 /* PhotosCondition.swift */,
 				1D9B43421B6A934A008F7F18 /* RemoteNotificationCondition.swift */,
 				1D9B43431B6A934A008F7F18 /* UserNotificationCondition.swift */,
@@ -361,6 +383,25 @@
 			path = PSOperationsAppForTestsTests;
 			sourceTree = "<group>";
 		};
+		FD8550131D2D8CCE00162079 /* PSOperationsHealth */ = {
+			isa = PBXGroup;
+			children = (
+				FD8550191D2D8D3400162079 /* HealthCapability.swift */,
+				FD85501A1D2D8D3400162079 /* HealthCondition.swift */,
+			);
+			name = PSOperationsHealth;
+			path = PSOperations;
+			sourceTree = "<group>";
+		};
+		FD8550141D2D8CDF00162079 /* PSOperationsPassbook */ = {
+			isa = PBXGroup;
+			children = (
+				FD8550151D2D8D1D00162079 /* PassbookCapability.swift */,
+				FD8550161D2D8D1D00162079 /* PassbookCondition.swift */,
+			);
+			name = PSOperationsPassbook;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -369,6 +410,22 @@
 			buildActionMask = 2147483647;
 			files = (
 				1D9B43141B6A92ED008F7F18 /* PSOperations.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FD854FD91D2D8CAB00162079 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FD854FDA1D2D8CAB00162079 /* PSOperations.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FD85500B1D2D8CC100162079 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FD85500C1D2D8CC100162079 /* PSOperations.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -446,6 +503,42 @@
 			productReference = FD19C9E31C440293005D0F07 /* PSOperationsAppForTestsTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		FD854FAF1D2D8CAB00162079 /* PSOperationsHealth */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FD854FDC1D2D8CAB00162079 /* Build configuration list for PBXNativeTarget "PSOperationsHealth" */;
+			buildPhases = (
+				FD854FB01D2D8CAB00162079 /* Sources */,
+				FD854FD81D2D8CAB00162079 /* Frameworks */,
+				FD854FD91D2D8CAB00162079 /* Headers */,
+				FD854FDB1D2D8CAB00162079 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = PSOperationsHealth;
+			productName = PSOperations;
+			productReference = FD854FDF1D2D8CAB00162079 /* PSOperationsHealth.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		FD854FE11D2D8CC100162079 /* PSOperationsPassbook */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FD85500E1D2D8CC100162079 /* Build configuration list for PBXNativeTarget "PSOperationsPassbook" */;
+			buildPhases = (
+				FD854FE21D2D8CC100162079 /* Sources */,
+				FD85500A1D2D8CC100162079 /* Frameworks */,
+				FD85500B1D2D8CC100162079 /* Headers */,
+				FD85500D1D2D8CC100162079 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = PSOperationsPassbook;
+			productName = PSOperations;
+			productReference = FD8550111D2D8CC100162079 /* PSOperationsPassbook.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -486,6 +579,8 @@
 			projectRoot = "";
 			targets = (
 				1D9B430D1B6A92ED008F7F18 /* PSOperations */,
+				FD854FAF1D2D8CAB00162079 /* PSOperationsHealth */,
+				FD854FE11D2D8CC100162079 /* PSOperationsPassbook */,
 				1D9B43181B6A92ED008F7F18 /* PSOperationsTests */,
 				FD19C9CF1C440293005D0F07 /* PSOperationsAppForTests */,
 				FD19C9E21C440293005D0F07 /* PSOperationsAppForTestsTests */,
@@ -525,6 +620,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FD854FDB1D2D8CAB00162079 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FD85500D1D2D8CC100162079 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -558,7 +667,6 @@
 				1D9B434C1B6A934A008F7F18 /* BlockOperation.swift in Sources */,
 				1D9B43631B6A934A008F7F18 /* Dictionary+Operations.swift in Sources */,
 				55AE64CD1BC1738D0097F4A5 /* LocationCapability-iOS.swift in Sources */,
-				1D9B435C1B6A934A008F7F18 /* PassbookCondition.swift in Sources */,
 				55AE64DA1BC1C7430097F4A5 /* PushCapability-iOS.swift in Sources */,
 				1D9B43571B6A934A008F7F18 /* NegatedCondition.swift in Sources */,
 				1D9B434D1B6A934A008F7F18 /* GroupOperation.swift in Sources */,
@@ -567,10 +675,7 @@
 				1D9B43501B6A934A008F7F18 /* DelayOperation.swift in Sources */,
 				55AE64D21BC180570097F4A5 /* LocationCapability-tvOS.swift in Sources */,
 				1D9B43541B6A934A008F7F18 /* OperationErrors.swift in Sources */,
-				55AE64CB1BC173560097F4A5 /* PassbookCapability.swift in Sources */,
-				55AE64D61BC19E330097F4A5 /* HealthCapability.swift in Sources */,
 				1D9B43561B6A934A008F7F18 /* SilentCondition.swift in Sources */,
-				1D9B43601B6A934A008F7F18 /* HealthCondition.swift in Sources */,
 				1D9B43661B6A934A008F7F18 /* UIUserNotifications+Operations.swift in Sources */,
 				1D9B435A1B6A934A008F7F18 /* ReachabilityCondition.swift in Sources */,
 				55AE64D41BC180650097F4A5 /* LocationCapability-OSX.swift in Sources */,
@@ -603,6 +708,24 @@
 			buildActionMask = 2147483647;
 			files = (
 				FD19C9E81C440293005D0F07 /* PSOperationsAppForTestsTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FD854FB01D2D8CAB00162079 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FD85501F1D2D8E0E00162079 /* HealthCapability.swift in Sources */,
+				FD8550201D2D8E0E00162079 /* HealthCondition.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FD854FE21D2D8CC100162079 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FD8550211D2D8E2200162079 /* PassbookCapability.swift in Sources */,
+				FD8550221D2D8E2200162079 /* PassbookCondition.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -855,6 +978,96 @@
 			};
 			name = Release;
 		};
+		FD854FDD1D2D8CAB00162079 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/PSOperations/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.pluralsight.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		FD854FDE1D2D8CAB00162079 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/PSOperations/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.pluralsight.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
+		FD85500F1D2D8CC100162079 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/PSOperations/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.pluralsight.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		FD8550101D2D8CC100162079 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/PSOperations/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.pluralsight.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -899,6 +1112,24 @@
 			buildConfigurations = (
 				FD19C9EE1C440293005D0F07 /* Debug */,
 				FD19C9EF1C440293005D0F07 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FD854FDC1D2D8CAB00162079 /* Build configuration list for PBXNativeTarget "PSOperationsHealth" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FD854FDD1D2D8CAB00162079 /* Debug */,
+				FD854FDE1D2D8CAB00162079 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FD85500E1D2D8CC100162079 /* Build configuration list for PBXNativeTarget "PSOperationsPassbook" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FD85500F1D2D8CC100162079 /* Debug */,
+				FD8550101D2D8CC100162079 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/PSOperations.xcodeproj/project.pbxproj
+++ b/PSOperations.xcodeproj/project.pbxproj
@@ -479,7 +479,7 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = Pluralsight;
 				TargetAttributes = {
 					1D9B430D1B6A92ED008F7F18 = {
@@ -781,6 +781,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -810,6 +811,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.pluralsight.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos macosx watchsimulator watchos";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
@@ -854,6 +856,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -899,6 +902,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};

--- a/PSOperations.xcodeproj/project.pbxproj
+++ b/PSOperations.xcodeproj/project.pbxproj
@@ -47,12 +47,6 @@
 		55AE64DA1BC1C7430097F4A5 /* PushCapability-iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64D91BC1C7430097F4A5 /* PushCapability-iOS.swift */; };
 		55AE64DC1BC1C7E50097F4A5 /* PushCapability-OSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64DB1BC1C7E50097F4A5 /* PushCapability-OSX.swift */; };
 		55AE64DE1BC1DCF50097F4A5 /* UserNotificationCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64DD1BC1DCF50097F4A5 /* UserNotificationCapability.swift */; };
-		FD19C9D31C440293005D0F07 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD19C9D21C440293005D0F07 /* AppDelegate.swift */; };
-		FD19C9D51C440293005D0F07 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD19C9D41C440293005D0F07 /* ViewController.swift */; };
-		FD19C9D81C440293005D0F07 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FD19C9D61C440293005D0F07 /* Main.storyboard */; };
-		FD19C9DA1C440293005D0F07 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FD19C9D91C440293005D0F07 /* Assets.xcassets */; };
-		FD19C9DD1C440293005D0F07 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FD19C9DB1C440293005D0F07 /* LaunchScreen.storyboard */; };
-		FD19C9E81C440293005D0F07 /* PSOperationsAppForTestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD19C9E71C440293005D0F07 /* PSOperationsAppForTestsTests.swift */; };
 		FD39C29E1B8B5F090092008B /* PSOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B436D1B6A942C008F7F18 /* PSOperationsTests.swift */; };
 		FD854FDA1D2D8CAB00162079 /* PSOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D9B43131B6A92ED008F7F18 /* PSOperations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FD85500C1D2D8CC100162079 /* PSOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D9B43131B6A92ED008F7F18 /* PSOperations.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -66,7 +60,6 @@
 		FDB1E8F21BBC2B08006BC157 /* OperationConditionResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB1E8F11BBC2B08006BC157 /* OperationConditionResultTests.swift */; };
 		FDC6C5291BBCDDC9008FB96E /* URLSessionTaskOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC6C5281BBCDDC9008FB96E /* URLSessionTaskOperationTests.swift */; };
 		FDC6C52C1BBD6447008FB96E /* OperationErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC6C52B1BBD6447008FB96E /* OperationErrorCodeTests.swift */; };
-		FDDB93431C6003A4009E0ABC /* PSOperations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D9B430E1B6A92ED008F7F18 /* PSOperations.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -76,13 +69,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 1D9B430D1B6A92ED008F7F18;
 			remoteInfo = PSOperations;
-		};
-		FD19C9E41C440293005D0F07 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1D9B43051B6A92ED008F7F18 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = FD19C9CF1C440293005D0F07;
-			remoteInfo = PSOperationsAppForTests;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -131,14 +117,12 @@
 		55AE64D91BC1C7430097F4A5 /* PushCapability-iOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PushCapability-iOS.swift"; sourceTree = "<group>"; };
 		55AE64DB1BC1C7E50097F4A5 /* PushCapability-OSX.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PushCapability-OSX.swift"; sourceTree = "<group>"; };
 		55AE64DD1BC1DCF50097F4A5 /* UserNotificationCapability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNotificationCapability.swift; sourceTree = "<group>"; };
-		FD19C9D01C440293005D0F07 /* PSOperationsAppForTests.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PSOperationsAppForTests.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD19C9D21C440293005D0F07 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FD19C9D41C440293005D0F07 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		FD19C9D71C440293005D0F07 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		FD19C9D91C440293005D0F07 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		FD19C9DC1C440293005D0F07 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		FD19C9DE1C440293005D0F07 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FD19C9E31C440293005D0F07 /* PSOperationsAppForTestsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PSOperationsAppForTestsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD19C9E71C440293005D0F07 /* PSOperationsAppForTestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PSOperationsAppForTestsTests.swift; sourceTree = "<group>"; };
 		FD19C9E91C440293005D0F07 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FD854FDF1D2D8CAB00162079 /* PSOperationsHealth.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PSOperationsHealth.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -166,21 +150,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				1D9B431A1B6A92ED008F7F18 /* PSOperations.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		FD19C9CD1C440293005D0F07 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				FDDB93431C6003A4009E0ABC /* PSOperations.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		FD19C9E01C440293005D0F07 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -221,8 +190,6 @@
 			children = (
 				1D9B430E1B6A92ED008F7F18 /* PSOperations.framework */,
 				1D9B43191B6A92ED008F7F18 /* PSOperationsTests.xctest */,
-				FD19C9D01C440293005D0F07 /* PSOperationsAppForTests.app */,
-				FD19C9E31C440293005D0F07 /* PSOperationsAppForTestsTests.xctest */,
 				FD854FDF1D2D8CAB00162079 /* PSOperationsHealth.framework */,
 				FD8550111D2D8CC100162079 /* PSOperationsPassbook.framework */,
 			);
@@ -468,41 +435,6 @@
 			productReference = 1D9B43191B6A92ED008F7F18 /* PSOperationsTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		FD19C9CF1C440293005D0F07 /* PSOperationsAppForTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = FD19C9EA1C440293005D0F07 /* Build configuration list for PBXNativeTarget "PSOperationsAppForTests" */;
-			buildPhases = (
-				FD19C9CC1C440293005D0F07 /* Sources */,
-				FD19C9CD1C440293005D0F07 /* Frameworks */,
-				FD19C9CE1C440293005D0F07 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = PSOperationsAppForTests;
-			productName = PSOperationsAppForTests;
-			productReference = FD19C9D01C440293005D0F07 /* PSOperationsAppForTests.app */;
-			productType = "com.apple.product-type.application";
-		};
-		FD19C9E21C440293005D0F07 /* PSOperationsAppForTestsTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = FD19C9ED1C440293005D0F07 /* Build configuration list for PBXNativeTarget "PSOperationsAppForTestsTests" */;
-			buildPhases = (
-				FD19C9DF1C440293005D0F07 /* Sources */,
-				FD19C9E01C440293005D0F07 /* Frameworks */,
-				FD19C9E11C440293005D0F07 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				FD19C9E51C440293005D0F07 /* PBXTargetDependency */,
-			);
-			name = PSOperationsAppForTestsTests;
-			productName = PSOperationsAppForTestsTests;
-			productReference = FD19C9E31C440293005D0F07 /* PSOperationsAppForTestsTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 		FD854FAF1D2D8CAB00162079 /* PSOperationsHealth */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FD854FDC1D2D8CAB00162079 /* Build configuration list for PBXNativeTarget "PSOperationsHealth" */;
@@ -558,13 +490,6 @@
 						CreatedOnToolsVersion = 6.4;
 						LastSwiftMigration = 0800;
 					};
-					FD19C9CF1C440293005D0F07 = {
-						CreatedOnToolsVersion = 7.2;
-					};
-					FD19C9E21C440293005D0F07 = {
-						CreatedOnToolsVersion = 7.2;
-						TestTargetID = FD19C9CF1C440293005D0F07;
-					};
 				};
 			};
 			buildConfigurationList = 1D9B43081B6A92ED008F7F18 /* Build configuration list for PBXProject "PSOperations" */;
@@ -584,8 +509,6 @@
 				FD854FAF1D2D8CAB00162079 /* PSOperationsHealth */,
 				FD854FE11D2D8CC100162079 /* PSOperationsPassbook */,
 				1D9B43181B6A92ED008F7F18 /* PSOperationsTests */,
-				FD19C9CF1C440293005D0F07 /* PSOperationsAppForTests */,
-				FD19C9E21C440293005D0F07 /* PSOperationsAppForTestsTests */,
 			);
 		};
 /* End PBXProject section */
@@ -599,23 +522,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		1D9B43171B6A92ED008F7F18 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		FD19C9CE1C440293005D0F07 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				FD19C9DD1C440293005D0F07 /* LaunchScreen.storyboard in Resources */,
-				FD19C9DA1C440293005D0F07 /* Assets.xcassets in Resources */,
-				FD19C9D81C440293005D0F07 /* Main.storyboard in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		FD19C9E11C440293005D0F07 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -696,23 +602,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FD19C9CC1C440293005D0F07 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				FD19C9D51C440293005D0F07 /* ViewController.swift in Sources */,
-				FD19C9D31C440293005D0F07 /* AppDelegate.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		FD19C9DF1C440293005D0F07 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				FD19C9E81C440293005D0F07 /* PSOperationsAppForTestsTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		FD854FB01D2D8CAB00162079 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -738,11 +627,6 @@
 			isa = PBXTargetDependency;
 			target = 1D9B430D1B6A92ED008F7F18 /* PSOperations */;
 			targetProxy = 1D9B431B1B6A92ED008F7F18 /* PBXContainerItemProxy */;
-		};
-		FD19C9E51C440293005D0F07 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = FD19C9CF1C440293005D0F07 /* PSOperationsAppForTests */;
-			targetProxy = FD19C9E41C440293005D0F07 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -930,60 +814,6 @@
 			};
 			name = Release;
 		};
-		FD19C9EB1C440293005D0F07 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				INFOPLIST_FILE = PSOperationsAppForTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.pluralsight.PSOperationsAppForTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		FD19C9EC1C440293005D0F07 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				INFOPLIST_FILE = PSOperationsAppForTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.pluralsight.PSOperationsAppForTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
-		};
-		FD19C9EE1C440293005D0F07 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				INFOPLIST_FILE = PSOperationsAppForTestsTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.pluralsight.PSOperationsAppForTestsTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PSOperationsAppForTests.app/PSOperationsAppForTests";
-			};
-			name = Debug;
-		};
-		FD19C9EF1C440293005D0F07 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				INFOPLIST_FILE = PSOperationsAppForTestsTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.pluralsight.PSOperationsAppForTestsTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PSOperationsAppForTests.app/PSOperationsAppForTests";
-			};
-			name = Release;
-		};
 		FD854FDD1D2D8CAB00162079 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1100,24 +930,6 @@
 			buildConfigurations = (
 				1D9B43281B6A92ED008F7F18 /* Debug */,
 				1D9B43291B6A92ED008F7F18 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		FD19C9EA1C440293005D0F07 /* Build configuration list for PBXNativeTarget "PSOperationsAppForTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				FD19C9EB1C440293005D0F07 /* Debug */,
-				FD19C9EC1C440293005D0F07 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		FD19C9ED1C440293005D0F07 /* Build configuration list for PBXNativeTarget "PSOperationsAppForTestsTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				FD19C9EE1C440293005D0F07 /* Debug */,
-				FD19C9EF1C440293005D0F07 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperations.xcscheme
+++ b/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperations.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsAppForTests.xcscheme
+++ b/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsAppForTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsHealth.xcscheme
+++ b/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsHealth.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsHealth.xcscheme
+++ b/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsHealth.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FD19C9CF1C440293005D0F07"
-               BuildableName = "PSOperationsAppForTests.app"
-               BlueprintName = "PSOperationsAppForTests"
+               BlueprintIdentifier = "FD854FAF1D2D8CAB00162079"
+               BuildableName = "PSOperationsHealth.framework"
+               BlueprintName = "PSOperationsHealth"
                ReferencedContainer = "container:PSOperations.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,26 +28,7 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FD19C9E21C440293005D0F07"
-               BuildableName = "PSOperationsAppForTestsTests.xctest"
-               BlueprintName = "PSOperationsAppForTestsTests"
-               ReferencedContainer = "container:PSOperations.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "FD19C9CF1C440293005D0F07"
-            BuildableName = "PSOperationsAppForTests.app"
-            BlueprintName = "PSOperationsAppForTests"
-            ReferencedContainer = "container:PSOperations.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -61,16 +42,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "FD19C9CF1C440293005D0F07"
-            BuildableName = "PSOperationsAppForTests.app"
-            BlueprintName = "PSOperationsAppForTests"
+            BlueprintIdentifier = "FD854FAF1D2D8CAB00162079"
+            BuildableName = "PSOperationsHealth.framework"
+            BlueprintName = "PSOperationsHealth"
             ReferencedContainer = "container:PSOperations.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -80,16 +60,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "FD19C9CF1C440293005D0F07"
-            BuildableName = "PSOperationsAppForTests.app"
-            BlueprintName = "PSOperationsAppForTests"
+            BlueprintIdentifier = "FD854FAF1D2D8CAB00162079"
+            BuildableName = "PSOperationsHealth.framework"
+            BlueprintName = "PSOperationsHealth"
             ReferencedContainer = "container:PSOperations.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsPassbook.xcscheme
+++ b/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsPassbook.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsPassbook.xcscheme
+++ b/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsPassbook.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FD19C9CF1C440293005D0F07"
-               BuildableName = "PSOperationsAppForTests.app"
-               BlueprintName = "PSOperationsAppForTests"
+               BlueprintIdentifier = "FD854FE11D2D8CC100162079"
+               BuildableName = "PSOperationsPassbook.framework"
+               BlueprintName = "PSOperationsPassbook"
                ReferencedContainer = "container:PSOperations.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,26 +28,7 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FD19C9E21C440293005D0F07"
-               BuildableName = "PSOperationsAppForTestsTests.xctest"
-               BlueprintName = "PSOperationsAppForTestsTests"
-               ReferencedContainer = "container:PSOperations.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "FD19C9CF1C440293005D0F07"
-            BuildableName = "PSOperationsAppForTests.app"
-            BlueprintName = "PSOperationsAppForTests"
-            ReferencedContainer = "container:PSOperations.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -61,16 +42,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "FD19C9CF1C440293005D0F07"
-            BuildableName = "PSOperationsAppForTests.app"
-            BlueprintName = "PSOperationsAppForTests"
+            BlueprintIdentifier = "FD854FE11D2D8CC100162079"
+            BuildableName = "PSOperationsPassbook.framework"
+            BlueprintName = "PSOperationsPassbook"
             ReferencedContainer = "container:PSOperations.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -80,16 +60,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "FD19C9CF1C440293005D0F07"
-            BuildableName = "PSOperationsAppForTests.app"
-            BlueprintName = "PSOperationsAppForTests"
+            BlueprintIdentifier = "FD854FE11D2D8CC100162079"
+            BuildableName = "PSOperationsPassbook.framework"
+            BlueprintName = "PSOperationsPassbook"
             ReferencedContainer = "container:PSOperations.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/PSOperations/BlockObserver.swift
+++ b/PSOperations/BlockObserver.swift
@@ -15,12 +15,12 @@ import Foundation
 public struct BlockObserver: OperationObserver {
     // MARK: Properties
     
-    private let startHandler: (Operation -> Void)?
-    private let cancelHandler: (Operation -> Void)?
-    private let produceHandler: ((Operation, NSOperation) -> Void)?
+    private let startHandler: ((Operation) -> Void)?
+    private let cancelHandler: ((Operation) -> Void)?
+    private let produceHandler: ((Operation, Foundation.Operation) -> Void)?
     private let finishHandler: ((Operation, [NSError]) -> Void)?
     
-    public init(startHandler: (Operation -> Void)? = nil, cancelHandler: (Operation -> Void)? = nil, produceHandler: ((Operation, NSOperation) -> Void)? = nil, finishHandler: ((Operation, [NSError]) -> Void)? = nil) {
+    public init(startHandler: ((Operation) -> Void)? = nil, cancelHandler: ((Operation) -> Void)? = nil, produceHandler: ((Operation, Foundation.Operation) -> Void)? = nil, finishHandler: ((Operation, [NSError]) -> Void)? = nil) {
         self.startHandler = startHandler
         self.cancelHandler = cancelHandler
         self.produceHandler = produceHandler
@@ -29,19 +29,19 @@ public struct BlockObserver: OperationObserver {
     
     // MARK: OperationObserver
     
-    public func operationDidStart(operation: Operation) {
+    public func operationDidStart(_ operation: Operation) {
         startHandler?(operation)
     }
     
-    public func operationDidCancel(operation: Operation) {
+    public func operationDidCancel(_ operation: Operation) {
         cancelHandler?(operation)
     }
     
-    public func operation(operation: Operation, didProduceOperation newOperation: NSOperation) {
+    public func operation(_ operation: Operation, didProduceOperation newOperation: Foundation.Operation) {
         produceHandler?(operation, newOperation)
     }
     
-    public func operationDidFinish(operation: Operation, errors: [NSError]) {
+    public func operationDidFinish(_ operation: Operation, errors: [NSError]) {
         finishHandler?(operation, errors)
     }
 }

--- a/PSOperations/BlockOperation.swift
+++ b/PSOperations/BlockOperation.swift
@@ -9,7 +9,7 @@ This code shows how to create a simple subclass of Operation.
 import Foundation
 
 /// A closure type that takes a closure as its parameter.
-public typealias OperationBlock = (Void -> Void) -> Void
+public typealias OperationBlock = ((Void) -> Void) -> Void
 
 /// A sublcass of `Operation` to execute a closure.
 public class BlockOperation: Operation {
@@ -37,9 +37,9 @@ public class BlockOperation: Operation {
             the designated initializer). The operation will be automatically ended 
             after the `mainQueueBlock` is executed.
     */
-    public convenience init(mainQueueBlock: dispatch_block_t) {
+    public convenience init(mainQueueBlock: ()->()) {
         self.init(block: { continuation in
-            dispatch_async(dispatch_get_main_queue()) {
+            DispatchQueue.main.async {
                 mainQueueBlock()
                 continuation()
             }

--- a/PSOperations/CKContainer+Operations.swift
+++ b/PSOperations/CKContainer+Operations.swift
@@ -26,7 +26,7 @@ extension CKContainer {
             operation fails. If the verification was successful, this value will
         be `nil`.
     */
-    func verifyPermission(permission: CKApplicationPermissions, requestingIfNecessary shouldRequest: Bool = false, completion: NSError? -> Void) {
+    func verifyPermission(_ permission: CKApplicationPermissions, requestingIfNecessary shouldRequest: Bool = false, completion: (NSError?) -> Void) {
         verifyAccountStatus(self, permission: permission, shouldRequest: shouldRequest, completion: completion)
     }
 }
@@ -35,9 +35,9 @@ extension CKContainer {
     Make these helper functions instead of helper methods, so we don't pollute
     `CKContainer`.
 */
-private func verifyAccountStatus(container: CKContainer, permission: CKApplicationPermissions, shouldRequest: Bool, completion: NSError? -> Void) {
-    container.accountStatusWithCompletionHandler { accountStatus, accountError in
-        if accountStatus == .Available {
+private func verifyAccountStatus(_ container: CKContainer, permission: CKApplicationPermissions, shouldRequest: Bool, completion: (NSError?) -> Void) {
+    container.accountStatus { accountStatus, accountError in
+        if accountStatus == .available {
             if permission != CKApplicationPermissions() {
                 verifyPermission(container, permission: permission, shouldRequest: shouldRequest, completion: completion)
             }
@@ -46,35 +46,35 @@ private func verifyAccountStatus(container: CKContainer, permission: CKApplicati
             }
         }
         else {
-            let error = accountError ?? NSError(domain: CKErrorDomain, code: CKErrorCode.NotAuthenticated.rawValue, userInfo: nil)
+            let error = accountError ?? NSError(domain: CKErrorDomain, code: CKErrorCode.notAuthenticated.rawValue, userInfo: nil)
             completion(error)
         }
     }
 }
 
-private func verifyPermission(container: CKContainer, permission: CKApplicationPermissions, shouldRequest: Bool, completion: NSError? -> Void) {
-    container.statusForApplicationPermission(permission) { permissionStatus, permissionError in
-        if permissionStatus == .Granted {
+private func verifyPermission(_ container: CKContainer, permission: CKApplicationPermissions, shouldRequest: Bool, completion: (NSError?) -> Void) {
+    container.status(forApplicationPermission: permission) { permissionStatus, permissionError in
+        if permissionStatus == .granted {
             completion(nil)
         }
-        else if permissionStatus == .InitialState && shouldRequest {
+        else if permissionStatus == .initialState && shouldRequest {
             requestPermission(container, permission: permission, completion: completion)
         }
         else {
-            let error = permissionError ?? NSError(domain: CKErrorDomain, code: CKErrorCode.PermissionFailure.rawValue, userInfo: nil)
+            let error = permissionError ?? NSError(domain: CKErrorDomain, code: CKErrorCode.permissionFailure.rawValue, userInfo: nil)
             completion(error)
         }
     }
 }
 
-private func requestPermission(container: CKContainer, permission: CKApplicationPermissions, completion: NSError? -> Void) {
-    dispatch_async(dispatch_get_main_queue()) {
+private func requestPermission(_ container: CKContainer, permission: CKApplicationPermissions, completion: (NSError?) -> Void) {
+    DispatchQueue.main.async {
         container.requestApplicationPermission(permission) { requestStatus, requestError in
-            if requestStatus == .Granted {
+            if requestStatus == .granted {
                 completion(nil)
             }
             else {
-                let error = requestError ?? NSError(domain: CKErrorDomain, code: CKErrorCode.PermissionFailure.rawValue, userInfo: nil)
+                let error = requestError ?? NSError(domain: CKErrorDomain, code: CKErrorCode.permissionFailure.rawValue, userInfo: nil)
                 completion(error)
             }
         }

--- a/PSOperations/CalendarCapability.swift
+++ b/PSOperations/CalendarCapability.swift
@@ -16,24 +16,24 @@ private let SharedEventStore = EKEventStore()
 extension EKEntityType: CapabilityType {
     public static var name: String { return "EKEntityType" }
     
-    public func requestStatus(completion: CapabilityStatus -> Void) {
-        let status = EKEventStore.authorizationStatusForEntityType(self)
+    public func requestStatus(_ completion: (CapabilityStatus) -> Void) {
+        let status = EKEventStore.authorizationStatus(for: self)
         switch status {
-            case .Authorized: completion(.Authorized)
-            case .Denied: completion(.Denied)
-            case .Restricted: completion(.NotAvailable)
-            case .NotDetermined: completion(.NotDetermined)
+            case .authorized: completion(.authorized)
+            case .denied: completion(.denied)
+            case .restricted: completion(.notAvailable)
+            case .notDetermined: completion(.notDetermined)
         }
     }
     
-    public func authorize(completion: CapabilityStatus -> Void) {
-        SharedEventStore.requestAccessToEntityType(self) { granted, error in
+    public func authorize(_ completion: (CapabilityStatus) -> Void) {
+        SharedEventStore.requestAccess(to: self) { granted, error in
             if granted {
-                completion(.Authorized)
+                completion(.authorized)
             } else if let error = error {
                 completion(.Error(error))
             } else {
-                completion(.NotAvailable)
+                completion(.notAvailable)
             }
         }
     }

--- a/PSOperations/CalendarCondition.swift
+++ b/PSOperations/CalendarCondition.swift
@@ -12,7 +12,7 @@ This file shows an example of implementing the OperationCondition protocol.
     
     /// A condition for verifying access to the user's calendar.
     
-    @available(*, deprecated, message="use Capability(EKEntityType....) instead")
+    @available(*, deprecated, message: "use Capability(EKEntityType....) instead")
     
     public struct CalendarCondition: OperationCondition {
         
@@ -26,23 +26,23 @@ This file shows an example of implementing the OperationCondition protocol.
             self.entityType = entityType
         }
         
-        public func dependencyForOperation(operation: Operation) -> NSOperation? {
+        public func dependencyForOperation(_ operation: Operation) -> Foundation.Operation? {
             return CalendarPermissionOperation(entityType: entityType)
         }
         
-        public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
-            switch EKEventStore.authorizationStatusForEntityType(entityType) {
-            case .Authorized:
-                completion(.Satisfied)
+        public func evaluateForOperation(_ operation: Operation, completion: (OperationConditionResult) -> Void) {
+            switch EKEventStore.authorizationStatus(for: entityType) {
+            case .authorized:
+                completion(.satisfied)
                 
             default:
                 // We are not authorized to access entities of this type.
-                let error = NSError(code: .ConditionFailed, userInfo: [
+                let error = NSError(code: .conditionFailed, userInfo: [
                     OperationConditionKey: self.dynamicType.name,
                     self.dynamicType.entityTypeKey: entityType.rawValue
                     ])
                 
-                completion(.Failed(error))
+                completion(.failed(error))
             }
         }
     }
@@ -68,12 +68,12 @@ This file shows an example of implementing the OperationCondition protocol.
         }
         
         override func execute() {
-            let status = EKEventStore.authorizationStatusForEntityType(entityType)
+            let status = EKEventStore.authorizationStatus(for: entityType)
             
             switch status {
-            case .NotDetermined:
-                dispatch_async(dispatch_get_main_queue()) {
-                    SharedEventStore.requestAccessToEntityType(self.entityType) { granted, error in
+            case .notDetermined:
+                DispatchQueue.main.async {
+                    SharedEventStore.requestAccess(to: self.entityType) { granted, error in
                         self.finish()
                     }
                 }

--- a/PSOperations/CloudCondition.swift
+++ b/PSOperations/CloudCondition.swift
@@ -11,7 +11,7 @@ This file shows an example of implementing the OperationCondition protocol.
 import CloudKit
 
 /// A condition describing that the operation requires access to a specific CloudKit container.
-@available(*, deprecated, message="use Capability(iCloudContainer(...)) instead")
+@available(*, deprecated, message: "use Capability(iCloudContainer(...)) instead")
     
 public struct CloudContainerCondition: OperationCondition {
     
@@ -40,23 +40,23 @@ public struct CloudContainerCondition: OperationCondition {
         self.permission = permission
     }
     
-    public func dependencyForOperation(operation: Operation) -> NSOperation? {
+    public func dependencyForOperation(_ operation: Operation) -> Foundation.Operation? {
         return CloudKitPermissionOperation(container: container, permission: permission)
     }
     
-    public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
+    public func evaluateForOperation(_ operation: Operation, completion: (OperationConditionResult) -> Void) {
         container.verifyPermission(permission, requestingIfNecessary: false) { error in
             if let error = error {
-                let conditionError = NSError(code: .ConditionFailed, userInfo: [
+                let conditionError = NSError(code: .conditionFailed, userInfo: [
                     OperationConditionKey: self.dynamicType.name,
                     self.dynamicType.containerKey: self.container,
                     NSUnderlyingErrorKey: error
                 ])
 
-                completion(.Failed(conditionError))
+                completion(.failed(conditionError))
             }
             else {
-                completion(.Satisfied)
+                completion(.satisfied)
             }
         }
     }

--- a/PSOperations/DelayOperation.swift
+++ b/PSOperations/DelayOperation.swift
@@ -62,7 +62,7 @@ public class DelayOperation: Operation {
         }
         
         let when = DispatchTime.now() + Double(Int64(interval * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
-        DispatchQueue.global(Int(UInt64(DispatchQueueAttributes.qosDefault.rawValue)), 0).after(when: when) {
+        DispatchQueue.global().after(when: when) {
             // If we were cancelled, then finish() has already been called.
             if !self.isCancelled {
                 self.finish()

--- a/PSOperations/DelayOperation.swift
+++ b/PSOperations/DelayOperation.swift
@@ -24,8 +24,8 @@ public class DelayOperation: Operation {
     // MARK: Types
 
     private enum Delay {
-        case Interval(NSTimeInterval)
-        case Date(NSDate)
+        case interval(TimeInterval)
+        case date(Foundation.Date)
     }
     
     // MARK: Properties
@@ -34,25 +34,25 @@ public class DelayOperation: Operation {
     
     // MARK: Initialization
     
-    public init(interval: NSTimeInterval) {
-        delay = .Interval(interval)
+    public init(interval: TimeInterval) {
+        delay = .interval(interval)
         super.init()
     }
     
-    public init(until date: NSDate) {
-        delay = .Date(date)
+    public init(until date: Date) {
+        delay = .date(date)
         super.init()
     }
     
     override public func execute() {
-        let interval: NSTimeInterval
+        let interval: TimeInterval
         
         // Figure out how long we should wait for.
         switch delay {
-            case .Interval(let theInterval):
+            case .interval(let theInterval):
                 interval = theInterval
 
-            case .Date(let date):
+            case .date(let date):
                 interval = date.timeIntervalSinceNow
         }
         
@@ -61,10 +61,10 @@ public class DelayOperation: Operation {
             return
         }
         
-        let when = dispatch_time(DISPATCH_TIME_NOW, Int64(interval * Double(NSEC_PER_SEC)))
-        dispatch_after(when, dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)) {
+        let when = DispatchTime.now() + Double(Int64(interval * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
+        DispatchQueue.global(Int(UInt64(DispatchQueueAttributes.qosDefault.rawValue)), 0).after(when: when) {
             // If we were cancelled, then finish() has already been called.
-            if !self.cancelled {
+            if !self.isCancelled {
                 self.finish()
             }
         }

--- a/PSOperations/Dictionary+Operations.swift
+++ b/PSOperations/Dictionary+Operations.swift
@@ -19,7 +19,7 @@ extension Dictionary {
             be used as the key for the value in the `Dictionary`. If the closure 
             returns `nil`, then the value will be omitted from the `Dictionary`.
     */
-    init<Sequence: SequenceType where Sequence.Generator.Element == Value>(sequence: Sequence, keyMapper: Value -> Key?) {
+    init<Sequence: Swift.Sequence where Sequence.Iterator.Element == Value>(sequence: Sequence, keyMapper: (Value) -> Key?) {
         self.init()
 
         for item in sequence {

--- a/PSOperations/ExclusivityController.swift
+++ b/PSOperations/ExclusivityController.swift
@@ -17,7 +17,7 @@ import Foundation
 class ExclusivityController {
     static let sharedExclusivityController = ExclusivityController()
     
-    private let serialQueue = dispatch_queue_create("Operations.ExclusivityController", DISPATCH_QUEUE_SERIAL)
+    private let serialQueue = DispatchQueue(label: "Operations.ExclusivityController", attributes: DispatchQueueAttributes.serial)
     private var operations: [String: [Operation]] = [:]
     
     private init() {
@@ -28,13 +28,13 @@ class ExclusivityController {
     }
     
     /// Registers an operation as being mutually exclusive
-    func addOperation(operation: Operation, categories: [String]) {
+    func addOperation(_ operation: Operation, categories: [String]) {
         /*
             This needs to be a synchronous operation.
             If this were async, then we might not get around to adding dependencies 
             until after the operation had already begun, which would be incorrect.
         */
-        dispatch_sync(serialQueue) {
+        serialQueue.sync {
             for category in categories {
                 self.noqueue_addOperation(operation, category: category)
             }
@@ -42,8 +42,8 @@ class ExclusivityController {
     }
     
     /// Unregisters an operation from being mutually exclusive.
-    func removeOperation(operation: Operation, categories: [String]) {
-        dispatch_async(serialQueue) {
+    func removeOperation(_ operation: Operation, categories: [String]) {
+        serialQueue.async {
             for category in categories {
                 self.noqueue_removeOperation(operation, category: category)
             }
@@ -53,7 +53,7 @@ class ExclusivityController {
     
     // MARK: Operation Management
     
-    private func noqueue_addOperation(operation: Operation, category: String) {
+    private func noqueue_addOperation(_ operation: Operation, category: String) {
         var operationsWithThisCategory = operations[category] ?? []
         
         if let last = operationsWithThisCategory.last {
@@ -65,13 +65,13 @@ class ExclusivityController {
         operations[category] = operationsWithThisCategory
     }
     
-    private func noqueue_removeOperation(operation: Operation, category: String) {
+    private func noqueue_removeOperation(_ operation: Operation, category: String) {
         let matchingOperations = operations[category]
 
         if var operationsWithThisCategory = matchingOperations,
-           let index = operationsWithThisCategory.indexOf(operation) {
+           let index = operationsWithThisCategory.index(of: operation) {
 
-            operationsWithThisCategory.removeAtIndex(index)
+            operationsWithThisCategory.remove(at: index)
             operations[category] = operationsWithThisCategory
         }
     }

--- a/PSOperations/GroupOperation.swift
+++ b/PSOperations/GroupOperation.swift
@@ -23,19 +23,19 @@ import Foundation
 */
 public class GroupOperation: Operation {
     private let internalQueue = OperationQueue()
-    private let startingOperation = NSBlockOperation(block: {})
-    private let finishingOperation = NSBlockOperation(block: {})
+    private let startingOperation = Foundation.BlockOperation(block: {})
+    private let finishingOperation = Foundation.BlockOperation(block: {})
 
     private var aggregatedErrors = [NSError]()
     
-    public convenience init(operations: NSOperation...) {
+    public convenience init(operations: Foundation.Operation...) {
         self.init(operations: operations)
     }
     
-    public init(operations: [NSOperation]) {
+    public init(operations: [Foundation.Operation]) {
         super.init()
         
-        internalQueue.suspended = true
+        internalQueue.isSuspended = true
         internalQueue.delegate = self
         internalQueue.addOperation(startingOperation)
         
@@ -46,16 +46,16 @@ public class GroupOperation: Operation {
     
     override public func cancel() {
         internalQueue.cancelAllOperations()
-        internalQueue.suspended = false
+        internalQueue.isSuspended = false
         super.cancel()
     }
     
     override public func execute() {
-        internalQueue.suspended = false
+        internalQueue.isSuspended = false
         internalQueue.addOperation(finishingOperation)
     }
     
-    public func addOperation(operation: NSOperation) {
+    public func addOperation(_ operation: Foundation.Operation) {
         internalQueue.addOperation(operation)
     }
     
@@ -64,18 +64,18 @@ public class GroupOperation: Operation {
         Errors aggregated through this method will be included in the final array 
         of errors reported to observers and to the `finished(_:)` method.
     */
-    public final func aggregateError(error: NSError) {
+    public final func aggregateError(_ error: NSError) {
         aggregatedErrors.append(error)
     }
     
-    public func operationDidFinish(operation: NSOperation, withErrors errors: [NSError]) {
+    public func operationDidFinish(_ operation: Foundation.Operation, withErrors errors: [NSError]) {
         // For use by subclassers.
     }
 }
 
 extension GroupOperation: OperationQueueDelegate {
-    final public func operationQueue(operationQueue: OperationQueue, willAddOperation operation: NSOperation) {
-        assert(!finishingOperation.finished && !finishingOperation.executing, "cannot add new operations to a group after the group has completed")
+    final public func operationQueue(_ operationQueue: OperationQueue, willAddOperation operation: Foundation.Operation) {
+        assert(!finishingOperation.isFinished && !finishingOperation.isExecuting, "cannot add new operations to a group after the group has completed")
         
         /*
             Some operation in this group has produced a new operation to execute.
@@ -99,11 +99,11 @@ extension GroupOperation: OperationQueueDelegate {
 
     }
     
-    final public func operationQueue(operationQueue: OperationQueue, operationDidFinish operation: NSOperation, withErrors errors: [NSError]) {
-        aggregatedErrors.appendContentsOf(errors)
+    final public func operationQueue(_ operationQueue: OperationQueue, operationDidFinish operation: Foundation.Operation, withErrors errors: [NSError]) {
+        aggregatedErrors.append(contentsOf: errors)
         
         if operation === finishingOperation {
-            internalQueue.suspended = true
+            internalQueue.isSuspended = true
             finish(aggregatedErrors)
         }
         else if operation !== startingOperation {

--- a/PSOperations/LocationCapability-OSX.swift
+++ b/PSOperations/LocationCapability-OSX.swift
@@ -63,7 +63,7 @@ private class LocationAuthorizer: NSObject, CLLocationManagerDelegate {
     }
     
     @objc func locationManager(manager: CLLocationManager, didChangeAuthorizationStatus status: CLAuthorizationStatus) {
-        if let completion = self.completion where manager == self.manager {
+        if let completion = self.completion, manager == self.manager {
             self.completion = nil
             
             switch status {

--- a/PSOperations/LocationCapability-iOS.swift
+++ b/PSOperations/LocationCapability-iOS.swift
@@ -14,34 +14,34 @@ import CoreLocation
 public enum Location: CapabilityType {
     public static let name = "Location"
     
-    case WhenInUse
-    case Always
+    case whenInUse
+    case always
     
-    public func requestStatus(completion: CapabilityStatus -> Void) {
+    public func requestStatus(_ completion: (CapabilityStatus) -> Void) {
         guard CLLocationManager.locationServicesEnabled() else {
-            completion(.NotAvailable)
+            completion(.notAvailable)
             return
         }
         
         let actual = CLLocationManager.authorizationStatus()
         
         switch actual {
-            case .NotDetermined: completion(.NotDetermined)
-            case .Restricted: completion(.NotAvailable)
-            case .Denied: completion(.Denied)
-            case .AuthorizedAlways: completion(.Authorized)
-            case .AuthorizedWhenInUse:
-                if self == .WhenInUse {
-                    completion(.Authorized)
+            case .notDetermined: completion(.notDetermined)
+            case .restricted: completion(.notAvailable)
+            case .denied: completion(.denied)
+            case .authorizedAlways: completion(.authorized)
+            case .authorizedWhenInUse:
+                if self == .whenInUse {
+                    completion(.authorized)
                 } else {
                     // the user wants .Always, but has .WhenInUse
                     // return .NotDetermined so that we can prompt to upgrade the permission
-                    completion(.NotDetermined)
+                    completion(.notDetermined)
                 }
         }
     }
     
-    public func authorize(completion: CapabilityStatus -> Void) {
+    public func authorize(_ completion: (CapabilityStatus) -> Void) {
         Authorizer.authorize(self, completion: completion)
     }
 }
@@ -51,15 +51,15 @@ private let Authorizer = LocationAuthorizer()
 private class LocationAuthorizer: NSObject, CLLocationManagerDelegate {
     
     private let manager = CLLocationManager()
-    private var completion: (CapabilityStatus -> Void)?
-    private var kind = Location.WhenInUse
+    private var completion: ((CapabilityStatus) -> Void)?
+    private var kind = Location.whenInUse
     
     override init() {
         super.init()
         manager.delegate = self
     }
     
-    func authorize(kind: Location, completion: CapabilityStatus -> Void) {
+    func authorize(_ kind: Location, completion: (CapabilityStatus) -> Void) {
         guard self.completion == nil else {
             fatalError("Attempting to authorize location when a request is already in-flight")
         }
@@ -68,33 +68,33 @@ private class LocationAuthorizer: NSObject, CLLocationManagerDelegate {
         
         let key: String
         switch kind {
-            case .WhenInUse:
+            case .whenInUse:
                 key = "NSLocationWhenInUseUsageDescription"
                 manager.requestWhenInUseAuthorization()
                 
-            case .Always:
+            case .always:
                 key = "NSLocationAlwaysUsageDescription"
                 manager.requestAlwaysAuthorization()
         }
         
         // This is helpful when developing an app.
-        assert(NSBundle.mainBundle().objectForInfoDictionaryKey(key) != nil, "Requesting location permission requires the \(key) key in your Info.plist")
+        assert(Bundle.main.objectForInfoDictionaryKey(key) != nil, "Requesting location permission requires the \(key) key in your Info.plist")
     }
     
-    @objc func locationManager(manager: CLLocationManager, didChangeAuthorizationStatus status: CLAuthorizationStatus) {
-        if let completion = self.completion where manager == self.manager && status != .NotDetermined {
+    @objc func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        if let completion = self.completion where manager == self.manager && status != .notDetermined {
             self.completion = nil
             
             switch status {
-                case .AuthorizedAlways:
-                    completion(.Authorized)
-                case .AuthorizedWhenInUse:
-                    completion(kind == .WhenInUse ? .Authorized : .Denied)
-                case .Denied:
-                    completion(.Denied)
-                case .Restricted:
-                    completion(.NotAvailable)
-                case .NotDetermined:
+                case .authorizedAlways:
+                    completion(.authorized)
+                case .authorizedWhenInUse:
+                    completion(kind == .whenInUse ? .authorized : .denied)
+                case .denied:
+                    completion(.denied)
+                case .restricted:
+                    completion(.notAvailable)
+                case .notDetermined:
                     fatalError("Unreachable due to the if statement, but included to keep clang happy")
             }
         }

--- a/PSOperations/LocationCapability-iOS.swift
+++ b/PSOperations/LocationCapability-iOS.swift
@@ -82,7 +82,7 @@ private class LocationAuthorizer: NSObject, CLLocationManagerDelegate {
     }
     
     @objc func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        if let completion = self.completion where manager == self.manager && status != .notDetermined {
+        if let completion = self.completion, manager == self.manager && status != .notDetermined {
             self.completion = nil
             
             switch status {

--- a/PSOperations/LocationCapability-tvOS.swift
+++ b/PSOperations/LocationCapability-tvOS.swift
@@ -65,7 +65,7 @@ private class LocationAuthorizer: NSObject, CLLocationManagerDelegate {
     }
     
     @objc func locationManager(manager: CLLocationManager, didChangeAuthorizationStatus status: CLAuthorizationStatus) {
-        if let completion = self.completion where manager == self.manager && status != .NotDetermined {
+        if let completion = self.completion, manager == self.manager && status != .NotDetermined {
             self.completion = nil
             
             switch status {

--- a/PSOperations/LocationOperation.swift
+++ b/PSOperations/LocationOperation.swift
@@ -73,7 +73,7 @@ public class LocationOperation: Operation, CLLocationManagerDelegate {
     // MARK: CLLocationManagerDelegate
     
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        if let location = locations.last where location.horizontalAccuracy <= accuracy {
+        if let location = locations.last, location.horizontalAccuracy <= accuracy {
             stopLocationUpdates()
             handler(location)
             finish()

--- a/PSOperations/LocationOperation.swift
+++ b/PSOperations/LocationOperation.swift
@@ -22,29 +22,29 @@ public class LocationOperation: Operation, CLLocationManagerDelegate {
     
     private let accuracy: CLLocationAccuracy
     private var manager: CLLocationManager?
-    private let handler: CLLocation -> Void
+    private let handler: (CLLocation) -> Void
     
     // MARK: Initialization
     
-    public init(accuracy: CLLocationAccuracy, locationHandler: CLLocation -> Void) {
+    public init(accuracy: CLLocationAccuracy, locationHandler: (CLLocation) -> Void) {
         self.accuracy = accuracy
         self.handler = locationHandler
         super.init()
         #if !os(tvOS)
-            addCondition(Capability(Location.WhenInUse))
+            addCondition(Capability(Location.whenInUse))
         #else
             addCondition(Capability(Location()))
         #endif
         addCondition(MutuallyExclusive<CLLocationManager>())
         addObserver(BlockObserver(cancelHandler: { [weak self] _ in
-            dispatch_async(dispatch_get_main_queue()) {
+            DispatchQueue.main.async {
                 self?.stopLocationUpdates()
             }
         }))
     }
     
     override public func execute() {
-        dispatch_async(dispatch_get_main_queue()) {
+        DispatchQueue.main.async {
             /*
             `CLLocationManager` needs to be created on a thread with an active
             run loop, so for simplicity we do this on the main queue.
@@ -72,7 +72,7 @@ public class LocationOperation: Operation, CLLocationManagerDelegate {
     
     // MARK: CLLocationManagerDelegate
     
-    public func locationManager(manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+    public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         if let location = locations.last where location.horizontalAccuracy <= accuracy {
             stopLocationUpdates()
             handler(location)
@@ -80,7 +80,7 @@ public class LocationOperation: Operation, CLLocationManagerDelegate {
         }
     }
     
-    public func locationManager(manager: CLLocationManager, didFailWithError error: NSError) {
+    public func locationManager(_ manager: CLLocationManager, didFailWithError error: NSError) {
         stopLocationUpdates()
         finishWithError(error)
     }

--- a/PSOperations/MutuallyExclusive.swift
+++ b/PSOperations/MutuallyExclusive.swift
@@ -20,12 +20,12 @@ public struct MutuallyExclusive<T>: OperationCondition {
     
     public init() { }
     
-    public func dependencyForOperation(operation: Operation) -> NSOperation? {
+    public func dependencyForOperation(_ operation: Operation) -> Foundation.Operation? {
         return nil
     }
     
-    public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
-        completion(.Satisfied)
+    public func evaluateForOperation(_ operation: Operation, completion: (OperationConditionResult) -> Void) {
+        completion(.satisfied)
     }
 }
 

--- a/PSOperations/NSLock+Operations.swift
+++ b/PSOperations/NSLock+Operations.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-extension NSLock {
-    func withCriticalScope<T>(@noescape block: Void -> T) -> T {
+extension Lock {
+    func withCriticalScope<T>(_ block: @noescape (Void) -> T) -> T {
         lock()
         let value = block()
         unlock()
@@ -17,8 +17,8 @@ extension NSLock {
     }
 }
 
-extension NSRecursiveLock {
-    func withCriticalScope<T>(@noescape block: Void -> T) -> T {
+extension RecursiveLock {
+    func withCriticalScope<T>(_ block: @noescape (Void) -> T) -> T {
         lock()
         let value = block()
         unlock()

--- a/PSOperations/NSOperation+Operations.swift
+++ b/PSOperations/NSOperation+Operations.swift
@@ -8,12 +8,12 @@ A convenient extension to Foundation.NSOperation.
 
 import Foundation
 
-extension NSOperation {
+extension Foundation.Operation {
     /** 
         Add a completion block to be executed after the `NSOperation` enters the
         "finished" state.
     */
-    func addCompletionBlock(block: Void -> Void) {
+    func addCompletionBlock(_ block: (Void) -> Void) {
         if let existing = completionBlock {
             /*
                 If we already have a completion block, we construct a new one by
@@ -30,7 +30,7 @@ extension NSOperation {
     }
 
     /// Add multiple depdendencies to the operation.
-    func addDependencies(dependencies: [NSOperation]) {
+    func addDependencies(_ dependencies: [Foundation.Operation]) {
         for dependency in dependencies {
             addDependency(dependency)
         }

--- a/PSOperations/NegatedCondition.swift
+++ b/PSOperations/NegatedCondition.swift
@@ -32,24 +32,24 @@ public struct NegatedCondition<T: OperationCondition>: OperationCondition {
         self.condition = condition
     }
     
-    public func dependencyForOperation(operation: Operation) -> NSOperation? {
+    public func dependencyForOperation(_ operation: Operation) -> Foundation.Operation? {
         return condition.dependencyForOperation(operation)
     }
     
-    public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
+    public func evaluateForOperation(_ operation: Operation, completion: (OperationConditionResult) -> Void) {
         condition.evaluateForOperation(operation) { result in
             switch result {
-            case .Failed(_):
+            case .failed(_):
                 // If the composed condition failed, then this one succeeded.
-                completion(.Satisfied)
-            case .Satisfied:
+                completion(.satisfied)
+            case .satisfied:
                 // If the composed condition succeeded, then this one failed.
-                let error = NSError(code: .ConditionFailed, userInfo: [
+                let error = NSError(code: .conditionFailed, userInfo: [
                     OperationConditionKey: self.dynamicType.name,
                     self.dynamicType.negatedConditionKey: self.condition.dynamicType.name
                     ])
                 
-                completion(.Failed(error))
+                completion(.failed(error))
             }
         }
     }

--- a/PSOperations/NoCancelledDependencies.swift
+++ b/PSOperations/NoCancelledDependencies.swift
@@ -22,25 +22,25 @@ public struct NoCancelledDependencies: OperationCondition {
         // No op.
     }
     
-    public func dependencyForOperation(operation: Operation) -> NSOperation? {
+    public func dependencyForOperation(_ operation: Operation) -> Foundation.Operation? {
         return nil
     }
     
-    public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
+    public func evaluateForOperation(_ operation: Operation, completion: (OperationConditionResult) -> Void) {
         // Verify that all of the dependencies executed.
-        let cancelled = operation.dependencies.filter { $0.cancelled }
+        let cancelled = operation.dependencies.filter { $0.isCancelled }
 
         if !cancelled.isEmpty {
             // At least one dependency was cancelled; the condition was not satisfied.
-            let error = NSError(code: .ConditionFailed, userInfo: [
+            let error = NSError(code: .conditionFailed, userInfo: [
                 OperationConditionKey: self.dynamicType.name,
                 self.dynamicType.cancelledDependenciesKey: cancelled
             ])
             
-            completion(.Failed(error))
+            completion(.failed(error))
         }
         else {
-            completion(.Satisfied)
+            completion(.satisfied)
         }
     }
 }

--- a/PSOperations/Operation.swift
+++ b/PSOperations/Operation.swift
@@ -322,6 +322,12 @@ public class Operation: NSOperation {
     }
     
     private var _internalErrors = [NSError]()
+  
+  
+    public var errors : [NSError] {
+        return _internalErrors
+    }
+  
     override public func cancel() {
         if finished {
             return
@@ -378,11 +384,12 @@ public class Operation: NSOperation {
             hasFinishedAlready = true
             state = .Finishing
             
-            let combinedErrors = _internalErrors + errors
-            finished(combinedErrors)
+            _internalErrors += errors
+          
+            finished(_internalErrors)
             
             for observer in observers {
-                observer.operationDidFinish(self, errors: combinedErrors)
+                observer.operationDidFinish(self, errors: _internalErrors)
             }
             
             state = .Finished

--- a/PSOperations/Operation.swift
+++ b/PSOperations/Operation.swift
@@ -268,7 +268,7 @@ public class Operation: Foundation.Operation {
         observers.append(observer)
     }
     
-    override public func addDependency(_ operation: Operation) {
+    override public func addDependency(_ operation: Foundation.Operation) {
         assert(state <= .executing, "Dependencies cannot be modified after execution has begun.")
 
         super.addDependency(operation)

--- a/PSOperations/Operation.swift
+++ b/PSOperations/Operation.swift
@@ -173,10 +173,8 @@ public class Operation: NSOperation {
                 // If super isReady, conditions can be evaluated
                 if super.ready {
                     evaluateConditions()
+                    _ready = state == .Ready
                 }
-                
-                // Until conditions have been evaluated, "isReady" returns false
-                _ready = false
                 
             case .Ready:
                 _ready = super.ready || cancelled

--- a/PSOperations/OperationCondition.swift
+++ b/PSOperations/OperationCondition.swift
@@ -39,10 +39,10 @@ public protocol OperationCondition {
             expressing that as multiple conditions. Alternatively, you could return
             a single `GroupOperation` that executes multiple operations internally.
     */
-    func dependencyForOperation(operation: Operation) -> NSOperation?
+    func dependencyForOperation(_ operation: Operation) -> Foundation.Operation?
     
     /// Evaluate the condition, to see if it has been satisfied or not.
-    func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void)
+    func evaluateForOperation(_ operation: Operation, completion: (OperationConditionResult) -> Void)
 }
 
 /**
@@ -50,12 +50,12 @@ public protocol OperationCondition {
     failed with an error.
 */
 public enum OperationConditionResult {
-    case Satisfied
-    case Failed(NSError)
+    case satisfied
+    case failed(NSError)
     
     var error: NSError? {
         switch self {
-        case .Failed(let error):
+        case .failed(let error):
             return error
         default:
             return nil
@@ -65,9 +65,9 @@ public enum OperationConditionResult {
 
 func ==(lhs: OperationConditionResult, rhs: OperationConditionResult) -> Bool {
     switch (lhs, rhs) {
-    case (.Satisfied, .Satisfied):
+    case (.satisfied, .satisfied):
         return true
-    case (.Failed(let lError), .Failed(let rError)) where lError == rError:
+    case (.failed(let lError), .failed(let rError)) where lError == rError:
         return true
     default:
         return false
@@ -78,23 +78,23 @@ func ==(lhs: OperationConditionResult, rhs: OperationConditionResult) -> Bool {
 // MARK: Evaluate Conditions
 
 struct OperationConditionEvaluator {
-    static func evaluate(conditions: [OperationCondition], operation: Operation, completion: [NSError] -> Void) {
+    static func evaluate(_ conditions: [OperationCondition], operation: Operation, completion: ([NSError]) -> Void) {
         // Check conditions.
-        let conditionGroup = dispatch_group_create()
+        let conditionGroup = DispatchGroup()
 
-        var results = [OperationConditionResult?](count: conditions.count, repeatedValue: nil)
+        var results = [OperationConditionResult?](repeating: nil, count: conditions.count)
         
         // Ask each condition to evaluate and store its result in the "results" array.
-        for (index, condition) in conditions.enumerate() {
-            dispatch_group_enter(conditionGroup)
+        for (index, condition) in conditions.enumerated() {
+            conditionGroup.enter()
             condition.evaluateForOperation(operation) { result in
                 results[index] = result
-                dispatch_group_leave(conditionGroup)
+                conditionGroup.leave()
             }
         }
         
         // After all the conditions have evaluated, this block will execute.
-        dispatch_group_notify(conditionGroup, dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)) {
+        conditionGroup.notify(queue: DispatchQueue.global(Int(UInt64(DispatchQueueAttributes.qosDefault.rawValue)), 0)) {
             // Aggregate the errors that occurred, in order.
             var failures = results.flatMap { $0?.error }
             
@@ -102,8 +102,8 @@ struct OperationConditionEvaluator {
                 If any of the conditions caused this operation to be cancelled, 
                 check for that.
             */
-            if operation.cancelled {
-                failures.append(NSError(code: .ConditionFailed))
+            if operation.isCancelled {
+                failures.append(NSError(code: .conditionFailed))
             }
             
             completion(failures)

--- a/PSOperations/OperationCondition.swift
+++ b/PSOperations/OperationCondition.swift
@@ -94,7 +94,7 @@ struct OperationConditionEvaluator {
         }
         
         // After all the conditions have evaluated, this block will execute.
-        conditionGroup.notify(queue: DispatchQueue.global(Int(UInt64(DispatchQueueAttributes.qosDefault.rawValue)), 0)) {
+        conditionGroup.notify(queue: DispatchQueue.global()) {
             // Aggregate the errors that occurred, in order.
             var failures = results.flatMap { $0?.error }
             

--- a/PSOperations/OperationErrors.swift
+++ b/PSOperations/OperationErrors.swift
@@ -11,8 +11,8 @@ import Foundation
 public let OperationErrorDomain = "OperationErrors"
 
 public enum OperationErrorCode: Int {
-    case ConditionFailed = 1
-    case ExecutionFailed = 2
+    case conditionFailed = 1
+    case executionFailed = 2
 }
 
 public extension NSError {

--- a/PSOperations/OperationObserver.swift
+++ b/PSOperations/OperationObserver.swift
@@ -15,18 +15,18 @@ import Foundation
 public protocol OperationObserver {
     
     /// Invoked immediately prior to the `Operation`'s `execute()` method.
-    func operationDidStart(operation: Operation)
+    func operationDidStart(_ operation: Operation)
     
     /// Invoked immediately after the first time the `Operation`'s `cancel()` method is called
-    func operationDidCancel(operation: Operation)
+    func operationDidCancel(_ operation: Operation)
     
     /// Invoked when `Operation.produceOperation(_:)` is executed.
-    func operation(operation: Operation, didProduceOperation newOperation: NSOperation)
+    func operation(_ operation: Operation, didProduceOperation newOperation: Foundation.Operation)
     
     /**
         Invoked as an `Operation` finishes, along with any errors produced during
         execution (or readiness evaluation).
     */
-    func operationDidFinish(operation: Operation, errors: [NSError])
+    func operationDidFinish(_ operation: Operation, errors: [NSError])
     
 }

--- a/PSOperations/OperationQueue.swift
+++ b/PSOperations/OperationQueue.swift
@@ -19,8 +19,8 @@ import Foundation
     `OperationQueue` and uses it to manage dependencies.
 */
 @objc public protocol OperationQueueDelegate: NSObjectProtocol {
-    optional func operationQueue(operationQueue: OperationQueue, willAddOperation operation: NSOperation)
-    optional func operationQueue(operationQueue: OperationQueue, operationDidFinish operation: NSOperation, withErrors errors: [NSError])
+    @objc optional func operationQueue(_ operationQueue: OperationQueue, willAddOperation operation: Foundation.Operation)
+    @objc optional func operationQueue(_ operationQueue: OperationQueue, operationDidFinish operation: Foundation.Operation, withErrors errors: [NSError])
 }
 
 /**
@@ -31,10 +31,10 @@ import Foundation
     - Extracting generated dependencies from operation conditions
     - Setting up dependencies to enforce mutual exclusivity
 */
-public class OperationQueue: NSOperationQueue {
+public class OperationQueue: Foundation.OperationQueue {
     public weak var delegate: OperationQueueDelegate?
     
-    override public  func addOperation(operation: NSOperation) {
+    override public  func addOperation(_ operation: Operation) {
         if let op = operation as? Operation {
             
             // Set up a `BlockObserver` to invoke the `OperationQueueDelegate` method.
@@ -116,7 +116,7 @@ public class OperationQueue: NSOperationQueue {
         }
     }
     
-    override public func addOperations(ops: [NSOperation], waitUntilFinished wait: Bool) {
+    override public func addOperations(_ ops: [Operation], waitUntilFinished wait: Bool) {
         /*
             The base implementation of this method does not call `addOperation()`,
             so we'll call it ourselves.

--- a/PSOperations/OperationQueue.swift
+++ b/PSOperations/OperationQueue.swift
@@ -34,7 +34,7 @@ import Foundation
 public class OperationQueue: Foundation.OperationQueue {
     public weak var delegate: OperationQueueDelegate?
     
-    override public  func addOperation(_ operation: Operation) {
+    override public func addOperation(_ operation: Foundation.Operation) {
         if let op = operation as? Operation {
             
             // Set up a `BlockObserver` to invoke the `OperationQueueDelegate` method.
@@ -116,7 +116,7 @@ public class OperationQueue: Foundation.OperationQueue {
         }
     }
     
-    override public func addOperations(_ ops: [Operation], waitUntilFinished wait: Bool) {
+    override public func addOperations(_ ops: [Foundation.Operation], waitUntilFinished wait: Bool) {
         /*
             The base implementation of this method does not call `addOperation()`,
             so we'll call it ourselves.

--- a/PSOperations/PhotosCapability.swift
+++ b/PSOperations/PhotosCapability.swift
@@ -16,23 +16,23 @@ public struct Photos: CapabilityType {
 
     public init() { }
     
-    public func requestStatus(completion: CapabilityStatus -> Void) {
+    public func requestStatus(_ completion: (CapabilityStatus) -> Void) {
         let status = PHPhotoLibrary.authorizationStatus()
         switch status {
-            case .Authorized: completion(.Authorized)
-            case .Denied: completion(.Denied)
-            case .Restricted: completion(.NotAvailable)
-            case .NotDetermined: completion(.NotDetermined)
+            case .authorized: completion(.authorized)
+            case .denied: completion(.denied)
+            case .restricted: completion(.notAvailable)
+            case .notDetermined: completion(.notDetermined)
         }
     }
     
-    public func authorize(completion: CapabilityStatus -> Void) {
+    public func authorize(_ completion: (CapabilityStatus) -> Void) {
         PHPhotoLibrary.requestAuthorization { status in
             switch status {
-                case .Authorized: completion(.Authorized)
-                case .Denied: completion(.Denied)
-                case .Restricted: completion(.NotAvailable)
-                case .NotDetermined: completion(.NotDetermined)
+                case .authorized: completion(.authorized)
+                case .denied: completion(.denied)
+                case .restricted: completion(.notAvailable)
+                case .notDetermined: completion(.notDetermined)
             }
         }
     }

--- a/PSOperations/PhotosCondition.swift
+++ b/PSOperations/PhotosCondition.swift
@@ -11,7 +11,7 @@ This file shows an example of implementing the OperationCondition protocol.
 import Photos
 
 /// A condition for verifying access to the user's Photos library.
-@available(*, deprecated, message="use Capability(Photos()) instead")
+@available(*, deprecated, message: "use Capability(Photos()) instead")
     
 public struct PhotosCondition: OperationCondition {
     
@@ -20,21 +20,21 @@ public struct PhotosCondition: OperationCondition {
     
     public init() { }
     
-    public func dependencyForOperation(operation: Operation) -> NSOperation? {
+    public func dependencyForOperation(_ operation: Operation) -> Foundation.Operation? {
         return PhotosPermissionOperation()
     }
     
-    public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
+    public func evaluateForOperation(_ operation: Operation, completion: (OperationConditionResult) -> Void) {
         switch PHPhotoLibrary.authorizationStatus() {
-            case .Authorized:
-                completion(.Satisfied)
+            case .authorized:
+                completion(.satisfied)
 
             default:
-                let error = NSError(code: .ConditionFailed, userInfo: [
+                let error = NSError(code: .conditionFailed, userInfo: [
                     OperationConditionKey: self.dynamicType.name
                 ])
 
-                completion(.Failed(error))
+                completion(.failed(error))
         }
     }
 }
@@ -52,8 +52,8 @@ class PhotosPermissionOperation: Operation {
     
     override func execute() {
         switch PHPhotoLibrary.authorizationStatus() {
-            case .NotDetermined:
-                dispatch_async(dispatch_get_main_queue()) {
+            case .notDetermined:
+                DispatchQueue.main.async {
                     PHPhotoLibrary.requestAuthorization { status in
                         self.finish()
                     }

--- a/PSOperations/PushCapability-iOS.swift
+++ b/PSOperations/PushCapability-iOS.swift
@@ -12,11 +12,11 @@ import UIKit
     
 public struct Push: CapabilityType {
     
-    public static func didReceiveToken(token: NSData) {
+    public static func didReceiveToken(_ token: Data) {
         authorizer.completeAuthorization(token, error: nil)
     }
     
-    public static func didFailRegistration(error: NSError) {
+    public static func didFailRegistration(_ error: NSError) {
         authorizer.completeAuthorization(nil, error: error)
     }
 
@@ -28,15 +28,15 @@ public struct Push: CapabilityType {
         }
     }
     
-    public func requestStatus(completion: CapabilityStatus -> Void) {
+    public func requestStatus(_ completion: (CapabilityStatus) -> Void) {
         if let _ = authorizer.token {
-            completion(.Authorized)
+            completion(.authorized)
         } else {
-            completion(.NotDetermined)
+            completion(.notDetermined)
         }
     }
     
-    public func authorize(completion: CapabilityStatus -> Void) {
+    public func authorize(_ completion: (CapabilityStatus) -> Void) {
         authorizer.authorize(completion)
     }
     
@@ -47,10 +47,10 @@ private let authorizer = PushAuthorizer()
 private class PushAuthorizer {
     
     var application: UIApplication?
-    var token: NSData?
-    var completion: (CapabilityStatus -> Void)?
+    var token: Data?
+    var completion: ((CapabilityStatus) -> Void)?
     
-    func authorize(completion: CapabilityStatus -> Void) {
+    func authorize(_ completion: (CapabilityStatus) -> Void) {
         guard self.completion == nil else {
             fatalError("Cannot request push authorization while a request is already in progress")
         }
@@ -64,18 +64,18 @@ private class PushAuthorizer {
         application.registerForRemoteNotifications()
     }
     
-    private func completeAuthorization(token: NSData?, error: NSError?) {
+    private func completeAuthorization(_ token: Data?, error: NSError?) {
         self.token = token
         
         guard let completion = self.completion else { return }
         self.completion = nil
         
         if let _ = self.token {
-            completion(.Authorized)
+            completion(.authorized)
         } else if let error = error {
             completion(.Error(error))
         } else {
-            completion(.NotDetermined)
+            completion(.notDetermined)
         }
     }
     

--- a/PSOperations/ReachabilityCondition.swift
+++ b/PSOperations/ReachabilityCondition.swift
@@ -21,29 +21,29 @@ public struct ReachabilityCondition: OperationCondition {
     public static let name = "Reachability"
     public static let isMutuallyExclusive = false
     
-    let host: NSURL
+    let host: URL
     
     
-    public init(host: NSURL) {
+    public init(host: URL) {
         self.host = host
     }
     
-    public func dependencyForOperation(operation: Operation) -> NSOperation? {
+    public func dependencyForOperation(_ operation: Operation) -> Foundation.Operation? {
         return nil
     }
     
-    public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
+    public func evaluateForOperation(_ operation: Operation, completion: (OperationConditionResult) -> Void) {
         ReachabilityController.requestReachability(host) { reachable in
             if reachable {
-                completion(.Satisfied)
+                completion(.satisfied)
             }
             else {
-                let error = NSError(code: .ConditionFailed, userInfo: [
+                let error = NSError(code: .conditionFailed, userInfo: [
                     OperationConditionKey: self.dynamicType.name,
                     self.dynamicType.hostKey: self.host
                 ])
                 
-                completion(.Failed(error))
+                completion(.failed(error))
             }
         }
     }
@@ -54,16 +54,16 @@ public struct ReachabilityCondition: OperationCondition {
 private class ReachabilityController {
     static var reachabilityRefs = [String: SCNetworkReachability]()
 
-    static let reachabilityQueue = dispatch_queue_create("Operations.Reachability", DISPATCH_QUEUE_SERIAL)
+    static let reachabilityQueue = DispatchQueue(label: "Operations.Reachability", attributes: DispatchQueueAttributes.serial)
     
-    static func requestReachability(url: NSURL, completionHandler: (Bool) -> Void) {
+    static func requestReachability(_ url: URL, completionHandler: (Bool) -> Void) {
         if let host = url.host {
-            dispatch_async(reachabilityQueue) {
+            reachabilityQueue.async {
                 var ref = self.reachabilityRefs[host]
                 
                 if ref == nil {
                     let hostString = host as NSString
-                    ref = SCNetworkReachabilityCreateWithName(nil, hostString.UTF8String)
+                    ref = SCNetworkReachabilityCreateWithName(nil, hostString.utf8String!)
                 }
                 
                 if let ref = ref {
@@ -78,7 +78,7 @@ private class ReachabilityController {
                         such as whether or not the connection would require
                         VPN, a cellular connection, etc.
                         */
-                        reachable = flags.contains(.Reachable)
+                        reachable = flags.contains(.reachable)
                     }
                     completionHandler(reachable)
                 }

--- a/PSOperations/SilentCondition.swift
+++ b/PSOperations/SilentCondition.swift
@@ -30,12 +30,12 @@ struct SilentCondition<T: OperationCondition>: OperationCondition {
         self.condition = condition
     }
     
-    public func dependencyForOperation(operation: Operation) -> NSOperation? {
+    public func dependencyForOperation(_ operation: Operation) -> Foundation.Operation? {
         // Returning nil means we will never a dependency to be generated.
         return nil
     }
     
-    public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
+    public func evaluateForOperation(_ operation: Operation, completion: (OperationConditionResult) -> Void) {
         condition.evaluateForOperation(operation, completion: completion)
     }
 }

--- a/PSOperations/TimeoutObserver.swift
+++ b/PSOperations/TimeoutObserver.swift
@@ -17,27 +17,27 @@ public struct TimeoutObserver: OperationObserver {
 
     static let timeoutKey = "Timeout"
     
-    private let timeout: NSTimeInterval
+    private let timeout: TimeInterval
     
     // MARK: Initialization
     
-    public init(timeout: NSTimeInterval) {
+    public init(timeout: TimeInterval) {
         self.timeout = timeout
     }
     
     // MARK: OperationObserver
     
-    public func operationDidStart(operation: Operation) {
+    public func operationDidStart(_ operation: Operation) {
         // When the operation starts, queue up a block to cause it to time out.
-        let when = dispatch_time(DISPATCH_TIME_NOW, Int64(timeout * Double(NSEC_PER_SEC)))
+        let when = DispatchTime.now() + Double(Int64(timeout * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
 
-        dispatch_after(when, dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)) {
+        DispatchQueue.global(Int(UInt64(DispatchQueueAttributes.qosDefault.rawValue)), 0).after(when: when) {
             /*
                 Cancel the operation if it hasn't finished and hasn't already 
                 been cancelled.
             */
-            if !operation.finished && !operation.cancelled {
-                let error = NSError(code: .ExecutionFailed, userInfo: [
+            if !operation.isFinished && !operation.isCancelled {
+                let error = NSError(code: .executionFailed, userInfo: [
                     self.dynamicType.timeoutKey: self.timeout
                 ])
 
@@ -46,15 +46,15 @@ public struct TimeoutObserver: OperationObserver {
         }
     }
     
-    public func operationDidCancel(operation: Operation) {
+    public func operationDidCancel(_ operation: Operation) {
         // No op.
     }
 
-    public func operation(operation: Operation, didProduceOperation newOperation: NSOperation) {
+    public func operation(_ operation: Operation, didProduceOperation newOperation: Foundation.Operation) {
         // No op.
     }
 
-    public func operationDidFinish(operation: Operation, errors: [NSError]) {
+    public func operationDidFinish(_ operation: Operation, errors: [NSError]) {
         // No op.
     }
 }

--- a/PSOperations/TimeoutObserver.swift
+++ b/PSOperations/TimeoutObserver.swift
@@ -31,7 +31,7 @@ public struct TimeoutObserver: OperationObserver {
         // When the operation starts, queue up a block to cause it to time out.
         let when = DispatchTime.now() + Double(Int64(timeout * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
 
-        DispatchQueue.global(Int(UInt64(DispatchQueueAttributes.qosDefault.rawValue)), 0).after(when: when) {
+        DispatchQueue.global().after(when: when) {
             /*
                 Cancel the operation if it hasn't finished and hasn't already 
                 been cancelled.

--- a/PSOperations/UIUserNotifications+Operations.swift
+++ b/PSOperations/UIUserNotifications+Operations.swift
@@ -12,7 +12,7 @@ import UIKit
 
 extension UIUserNotificationSettings {
     /// Check to see if one Settings object is a superset of another Settings object.
-    func contains(settings: UIUserNotificationSettings) -> Bool {
+    func contains(_ settings: UIUserNotificationSettings) -> Bool {
         // our types must contain all of the other types
         if !types.contains(settings.types) {
             return false
@@ -21,14 +21,14 @@ extension UIUserNotificationSettings {
         let otherCategories = settings.categories ?? []
         let myCategories = categories ?? []
         
-        return myCategories.isSupersetOf(otherCategories)
+        return myCategories.isSuperset(of: otherCategories)
     }
     
     /**
         Merge two Settings objects together. `UIUserNotificationCategories` with 
         the same identifier are considered equal.
     */
-    func settingsByMerging(settings: UIUserNotificationSettings) -> UIUserNotificationSettings {
+    func settingsByMerging(_ settings: UIUserNotificationSettings) -> UIUserNotificationSettings {
         let mergedTypes = types.union(settings.types)
         
         let myCategories = categories ?? []
@@ -42,7 +42,7 @@ extension UIUserNotificationSettings {
         }
         
         let mergedCategories = Set(existingCategoriesByIdentifier.values)
-        return UIUserNotificationSettings(forTypes: mergedTypes, categories: mergedCategories)
+        return UIUserNotificationSettings(types: mergedTypes, categories: mergedCategories)
     }
 }
 

--- a/PSOperations/URLSessionTaskOperation.swift
+++ b/PSOperations/URLSessionTaskOperation.swift
@@ -22,13 +22,13 @@ private var URLSessionTaskOperationKVOContext = 0
     An example usage of `URLSessionTaskOperation` can be seen in the `DownloadEarthquakesOperation`.
 */
 public class URLSessionTaskOperation: Operation {
-    let task: NSURLSessionTask
+    let task: URLSessionTask
     
     private var observerRemoved = false
-    private let stateLock = NSLock()
+    private let stateLock = Lock()
     
-    public init(task: NSURLSessionTask) {
-        assert(task.state == .Suspended, "Tasks must be suspended.")
+    public init(task: URLSessionTask) {
+        assert(task.state == .suspended, "Tasks must be suspended.")
         self.task = task
         super.init()
         
@@ -38,23 +38,23 @@ public class URLSessionTaskOperation: Operation {
     }
     
     override public func execute() {
-        assert(task.state == .Suspended, "Task was resumed by something other than \(self).")
+        assert(task.state == .suspended, "Task was resumed by something other than \(self).")
 
         task.addObserver(self, forKeyPath: "state", options: NSKeyValueObservingOptions(), context: &URLSessionTaskOperationKVOContext)
         
         task.resume()
     }
     
-    override public func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
+    override public func observeValue(forKeyPath keyPath: String?, of object: AnyObject?, change: [NSKeyValueChangeKey : AnyObject]?, context: UnsafeMutablePointer<Void>?) {
         guard context == &URLSessionTaskOperationKVOContext else { return }
         
         stateLock.withCriticalScope {
             if object === task && keyPath == "state" && !observerRemoved {
                 switch task.state {
-                case .Completed:
+                case .completed:
                     finish()
                     fallthrough
-                case .Canceling:
+                case .canceling:
                     observerRemoved = true
                     task.removeObserver(self, forKeyPath: "state")
                 default:

--- a/PSOperations/UserNotificationCapability.swift
+++ b/PSOperations/UserNotificationCapability.swift
@@ -19,14 +19,14 @@ public struct UserNotification: CapabilityType {
     }
     
     public enum Behavior {
-        case Replace
-        case Merge
+        case replace
+        case merge
     }
     
     private let settings: UIUserNotificationSettings
     private let behavior: Behavior
     
-    public init(settings: UIUserNotificationSettings, behavior: Behavior = .Merge, application: UIApplication) {
+    public init(settings: UIUserNotificationSettings, behavior: Behavior = .merge, application: UIApplication) {
         self.settings = settings
         self.behavior = behavior
         
@@ -35,18 +35,18 @@ public struct UserNotification: CapabilityType {
         }
     }
     
-    public func requestStatus(completion: CapabilityStatus -> Void) {
+    public func requestStatus(_ completion: (CapabilityStatus) -> Void) {
         let registered = authorizer.areSettingsRegistered(settings)
-        completion(registered ? .Authorized : .NotDetermined)
+        completion(registered ? .authorized : .notDetermined)
     }
     
-    public func authorize(completion: CapabilityStatus -> Void) {
+    public func authorize(_ completion: (CapabilityStatus) -> Void) {
         let settings: UIUserNotificationSettings
         
         switch behavior {
-            case .Replace:
+            case .replace:
                 settings = self.settings
-            case .Merge:
+            case .merge:
                 let current = authorizer.application.currentUserNotificationSettings()
                 settings = current?.settingsByMerging(self.settings) ?? self.settings
         }
@@ -73,16 +73,16 @@ private class UserNotificationAuthorizer {
             return application
         }
     }
-    var completion: (CapabilityStatus -> Void)?
+    var completion: ((CapabilityStatus) -> Void)?
     var settings: UIUserNotificationSettings?
     
-    func areSettingsRegistered(settings: UIUserNotificationSettings) -> Bool {
+    func areSettingsRegistered(_ settings: UIUserNotificationSettings) -> Bool {
         let current = application.currentUserNotificationSettings()
         
         return current?.contains(settings) ?? false
     }
     
-    func authorize(settings: UIUserNotificationSettings, completion: CapabilityStatus -> Void) {
+    func authorize(_ settings: UIUserNotificationSettings, completion: (CapabilityStatus) -> Void) {
         guard self.completion == nil else {
             fatalError("Cannot request push authorization while a request is already in progress")
         }
@@ -105,7 +105,7 @@ private class UserNotificationAuthorizer {
         self.settings = nil
         
         let registered = areSettingsRegistered(settings)
-        completion(registered ? .Authorized : .Denied)
+        completion(registered ? .authorized : .denied)
     }
     
 }

--- a/PSOperations/UserNotificationCondition.swift
+++ b/PSOperations/UserNotificationCondition.swift
@@ -14,16 +14,16 @@ import UIKit
     A condition for verifying that we can present alerts to the user via 
     `UILocalNotification` and/or remote notifications.
 */
-@available(*, deprecated, message="use Capability(UserNotification(...)) instead")
+@available(*, deprecated, message: "use Capability(UserNotification(...)) instead")
 
 public struct UserNotificationCondition: OperationCondition {
     
     public enum Behavior {
         /// Merge the new `UIUserNotificationSettings` with the `currentUserNotificationSettings`.
-        case Merge
+        case merge
 
         /// Replace the `currentUserNotificationSettings` with the new `UIUserNotificationSettings`.
-        case Replace
+        case replace
     }
     
     public static let name = "UserNotification"
@@ -50,33 +50,33 @@ public struct UserNotificationCondition: OperationCondition {
             `application`. You may also specify `.Replace`, which means the `settings` 
             will overwrite the exisiting settings.
     */
-    public init(settings: UIUserNotificationSettings, application: UIApplication, behavior: Behavior = .Merge) {
+    public init(settings: UIUserNotificationSettings, application: UIApplication, behavior: Behavior = .merge) {
         self.settings = settings
         self.application = application
         self.behavior = behavior
     }
     
-    public func dependencyForOperation(operation: Operation) -> NSOperation? {
+    public func dependencyForOperation(_ operation: Operation) -> Foundation.Operation? {
         return UserNotificationPermissionOperation(settings: settings, application: application, behavior: behavior)
     }
     
-    public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
+    public func evaluateForOperation(_ operation: Operation, completion: (OperationConditionResult) -> Void) {
         let result: OperationConditionResult
         
         let current = application.currentUserNotificationSettings()
         
         switch (current, settings)  {
         case (let current?, let settings) where current.contains(settings):
-            result = .Satisfied
+            result = .satisfied
             
         default:
-            let error = NSError(code: .ConditionFailed, userInfo: [
+            let error = NSError(code: .conditionFailed, userInfo: [
                 OperationConditionKey: self.dynamicType.name,
                 self.dynamicType.currentSettings: current ?? NSNull(),
                 self.dynamicType.desiredSettings: settings
                 ])
             
-            result = .Failed(error)
+            result = .failed(error)
         }
         
         completion(result)
@@ -103,13 +103,13 @@ private class UserNotificationPermissionOperation: Operation {
     }
     
     override func execute() {
-        dispatch_async(dispatch_get_main_queue()) {
+        DispatchQueue.main.async {
             let current = self.application.currentUserNotificationSettings()
             
             let settingsToRegister: UIUserNotificationSettings
             
             switch (current, self.behavior) {
-            case (let currentSettings?, .Merge):
+            case (let currentSettings?, .merge):
                 settingsToRegister = currentSettings.settingsByMerging(self.settings)
                 
             default:

--- a/PSOperations/iCloudContainerCapability.swift
+++ b/PSOperations/iCloudContainerCapability.swift
@@ -23,61 +23,61 @@ public struct iCloudContainer: CapabilityType {
         self.permissions = permissions
     }
     
-    public func requestStatus(completion: CapabilityStatus -> Void) {
+    public func requestStatus(_ completion: (CapabilityStatus) -> Void) {
         verifyAccountStatus(container, permission: permissions, shouldRequest: false, completion: completion)
     }
     
-    public func authorize(completion: CapabilityStatus -> Void) {
+    public func authorize(_ completion: (CapabilityStatus) -> Void) {
         verifyAccountStatus(container, permission: permissions, shouldRequest: true, completion: completion)
     }
     
 }
 
-private func verifyAccountStatus(container: CKContainer, permission: CKApplicationPermissions, shouldRequest: Bool, completion: CapabilityStatus -> Void) {
-    container.accountStatusWithCompletionHandler { accountStatus, accountError in
+private func verifyAccountStatus(_ container: CKContainer, permission: CKApplicationPermissions, shouldRequest: Bool, completion: (CapabilityStatus) -> Void) {
+    container.accountStatus { accountStatus, accountError in
         switch accountStatus {
-            case .NoAccount: completion(.NotAvailable)
-            case .Restricted: completion(.NotAvailable)
-            case .CouldNotDetermine:
-                let error = accountError ?? NSError(domain: CKErrorDomain, code: CKErrorCode.NotAuthenticated.rawValue, userInfo: nil)
+            case .noAccount: completion(.notAvailable)
+            case .restricted: completion(.notAvailable)
+            case .couldNotDetermine:
+                let error = accountError ?? NSError(domain: CKErrorDomain, code: CKErrorCode.notAuthenticated.rawValue, userInfo: nil)
                 completion(.Error(error))
-            case .Available:
+            case .available:
                 if permission != [] {
                     verifyPermission(container, permission: permission, shouldRequest: shouldRequest, completion: completion)
                 } else {
-                    completion(.Authorized)
+                    completion(.authorized)
                 }
         }
     }
 }
 
-private func verifyPermission(container: CKContainer, permission: CKApplicationPermissions, shouldRequest: Bool, completion: CapabilityStatus -> Void) {
-    container.statusForApplicationPermission(permission) { permissionStatus, permissionError in
+private func verifyPermission(_ container: CKContainer, permission: CKApplicationPermissions, shouldRequest: Bool, completion: (CapabilityStatus) -> Void) {
+    container.status(forApplicationPermission: permission) { permissionStatus, permissionError in
         switch permissionStatus {
-            case .InitialState:
+            case .initialState:
                 if shouldRequest {
                     requestPermission(container, permission: permission, completion: completion)
                 } else {
-                    completion(.NotDetermined)
+                    completion(.notDetermined)
                 }
-            case .Denied: completion(.Denied)
-            case .Granted: completion(.Authorized)
-            case .CouldNotComplete:
-                let error = permissionError ?? NSError(domain: CKErrorDomain, code: CKErrorCode.PermissionFailure.rawValue, userInfo: nil)
+            case .denied: completion(.denied)
+            case .granted: completion(.authorized)
+            case .couldNotComplete:
+                let error = permissionError ?? NSError(domain: CKErrorDomain, code: CKErrorCode.permissionFailure.rawValue, userInfo: nil)
                 completion(.Error(error))
         }
     }
 }
 
-private func requestPermission(container: CKContainer, permission: CKApplicationPermissions, completion: CapabilityStatus -> Void) {
-    dispatch_async(dispatch_get_main_queue()) {
+private func requestPermission(_ container: CKContainer, permission: CKApplicationPermissions, completion: (CapabilityStatus) -> Void) {
+    DispatchQueue.main.async {
         container.requestApplicationPermission(permission) { requestStatus, requestError in
             switch requestStatus {
-                case .InitialState: completion(.NotDetermined)
-                case .Denied: completion(.Denied)
-                case .Granted: completion(.Authorized)
-                case .CouldNotComplete:
-                    let error = requestError ?? NSError(domain: CKErrorDomain, code: CKErrorCode.PermissionFailure.rawValue, userInfo: nil)
+                case .initialState: completion(.notDetermined)
+                case .denied: completion(.denied)
+                case .granted: completion(.authorized)
+                case .couldNotComplete:
+                    let error = requestError ?? NSError(domain: CKErrorDomain, code: CKErrorCode.permissionFailure.rawValue, userInfo: nil)
                     completion(.Error(error))
             }
         }

--- a/PSOperationsHealth/HealthCapability.swift
+++ b/PSOperationsHealth/HealthCapability.swift
@@ -10,6 +10,7 @@
 
 import Foundation
 import HealthKit
+import PSOperations
 
 public struct Health: CapabilityType {
     public static let name = "Health"

--- a/PSOperationsHealth/HealthCondition.swift
+++ b/PSOperationsHealth/HealthCondition.swift
@@ -10,6 +10,7 @@ This file shows an example of implementing the OperationCondition protocol.
     
 import HealthKit
 import UIKit
+import PSOperations
 
 /**
     A condition to indicate an `Operation` requires access to the user's health

--- a/PSOperationsPassbook/PassbookCapability.swift
+++ b/PSOperationsPassbook/PassbookCapability.swift
@@ -10,6 +10,7 @@
 
 import Foundation
 import PassKit
+import PSOperations
 
 public enum Passbook: CapabilityType {
     public static let name = "Passbook"

--- a/PSOperationsPassbook/PassbookCondition.swift
+++ b/PSOperationsPassbook/PassbookCondition.swift
@@ -9,6 +9,7 @@ This file shows an example of implementing the OperationCondition protocol.
 #if os(iOS)
     
 import PassKit
+import PSOperations
 
 /// A condition for verifying that Passbook exists and is accessible.
 @available(*, deprecated, message="use Capability(Passbook....) instead")

--- a/PSOperationsTests/PSOperationsTests.swift
+++ b/PSOperationsTests/PSOperationsTests.swift
@@ -1059,6 +1059,34 @@ class PSOperationsTests: XCTestCase {
         }
     }
     
+    
+    
+    func testOperationDidStartWhenSetMaxConcurrencyCountOnTheQueue() {
+        
+        let opQueue = OperationQueue()
+        opQueue.maxConcurrentOperationCount = 1;
+        
+        let exp1 = expectationWithDescription("1")
+        let exp2 = expectationWithDescription("2")
+        let exp3 = expectationWithDescription("3")
+        
+        let op1 = BlockOperation {
+            exp1.fulfill()
+        }
+        let op2 = BlockOperation {
+            exp2.fulfill()
+        }
+        let op3 = BlockOperation {
+            exp3.fulfill()
+        }
+        
+        
+        opQueue.addOperation(op1)
+        opQueue.addOperation(op2)
+        opQueue.addOperation(op3)
+        
+        waitForExpectationsWithTimeout(1.0, handler: nil)
+    }
     func testOperationFinishedWithErrors() {
         let opQ = OperationQueue()
         

--- a/PSOperationsTests/PSOperationsTests.swift
+++ b/PSOperationsTests/PSOperationsTests.swift
@@ -1056,4 +1056,59 @@ class PSOperationsTests: XCTestCase {
             XCTAssertEqual(opCount, requiredToPassCount)
         }
     }
+    
+    func testOperationFinishedWithErrors() {
+        let opQ = OperationQueue()
+        
+        class ErrorOp : Operation {
+            
+            let sema = dispatch_semaphore_create(0)
+            
+            override func execute() {
+                finishWithError(NSError(code: .ExecutionFailed))
+            }
+            
+            override func finished(errors: [NSError]) {
+                dispatch_semaphore_signal(sema)
+            }
+            
+            override func waitUntilFinished() {
+                dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER)
+            }
+        }
+        
+        let op = ErrorOp()
+        
+        opQ.addOperations([op], waitUntilFinished: true)
+        
+        XCTAssertEqual(op.errors, [NSError(code: .ExecutionFailed)])
+    }
+    
+    func testOperationCancelledWithErrors() {
+        let opQ = OperationQueue()
+        
+        class ErrorOp : Operation {
+            
+            let sema = dispatch_semaphore_create(0)
+            
+            override func execute() {
+                cancelWithError(NSError(code: .ExecutionFailed))
+            }
+            
+            override func finished(errors: [NSError]) {
+                dispatch_semaphore_signal(sema)
+            }
+            
+            override func waitUntilFinished() {
+                dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER)
+            }
+        }
+        
+        let op = ErrorOp()
+        
+        opQ.addOperations([op], waitUntilFinished: true)
+        
+        XCTAssertEqual(op.errors, [NSError(code: .ExecutionFailed)])
+    }
+    
 }

--- a/PSOperationsTests/PSOperationsTests.swift
+++ b/PSOperationsTests/PSOperationsTests.swift
@@ -986,7 +986,7 @@ class PSOperationsTests: XCTestCase {
         
     }
     
-    
+    /* I'm not sure what this test is testing and the Foundation waitUntilFinished is being fickle
     func testOperationQueueWaitUntilFinished() {
         let opQ = OperationQueue()
         
@@ -1007,6 +1007,7 @@ class PSOperationsTests: XCTestCase {
         XCTAssertEqual(0, opQ.operationCount)
         XCTAssertTrue(op.waitCalled)
     }
+    */
     
     /*
         In 9.1 (at least) we found that occasionaly OperationQueue would get stuck on an operation

--- a/PSOperationsTests/PSOperationsTests.swift
+++ b/PSOperationsTests/PSOperationsTests.swift
@@ -990,12 +990,13 @@ class PSOperationsTests: XCTestCase {
     func testOperationQueueWaitUntilFinished() {
         let opQ = OperationQueue()
         
-        class WaitOp : Operation {
+        class WaitOp : NSOperation {
             
             var waitCalled = false
             
             override func waitUntilFinished() {
                 waitCalled = true
+                super.waitUntilFinished()
             }
         }
         
@@ -1003,7 +1004,7 @@ class PSOperationsTests: XCTestCase {
         
         opQ.addOperations([op], waitUntilFinished: true)
         
-        XCTAssertEqual(1, opQ.operationCount)
+        XCTAssertEqual(0, opQ.operationCount)
         XCTAssertTrue(op.waitCalled)
     }
     

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 This is an adaptation of the sample code provided in the Advanced NSOperations session of WWDC 2015. This code has been updated to work with the latest Swift changes as of Xcode 7. For usage examples, see [WWDC 2015 Advanced NSOperations](https://developer.apple.com/videos/wwdc/2015/?id=226) and/or look at the included unit tests.
 
+**Subframeworks:**
+
+- If you need the HealthCapability you will need to link and import `PSOperationsHealth` into your project.
+- If you need the PassbookCapability you will need to link and import `PSOperationsPassbook` into your project.
+
 Feel free to fork and submit pull requests, as we are always looking for improvements from the community.
 
 Differences from the first version of the WWDC sample code:

--- a/README.md
+++ b/README.md
@@ -2,25 +2,262 @@
 
 [![codebeat badge](https://codebeat.co/badges/5a8fa0e4-178b-499b-9947-98bf69013b7f)](https://codebeat.co/projects/github-com-pluralsight-psoperations) ![](https://travis-ci.org/pluralsight/PSOperations.svg)
 
-This is an adaptation of the sample code provided in the Advanced NSOperations session of WWDC 2015. This code has been updated to work with the latest Swift changes as of Xcode 7. For usage examples, see [WWDC 2015 Advanced NSOperations](https://developer.apple.com/videos/wwdc/2015/?id=226) and/or look at the included unit tests.
+PSOperations is a framework that leverages the power of NSOperation and NSOperationQueue. It enables you to use operations more easily in all parts of your project.
 
-**Subframeworks:**
+This is an adaptation of the sample code provided in the [Advanced NSOperations](https://developer.apple.com/videos/wwdc/2015/?id=226) session of WWDC 2015.
 
-- If you need the HealthCapability you will need to link and import `PSOperationsHealth` into your project.
-- If you need the PassbookCapability you will need to link and import `PSOperationsPassbook` into your project.
 
-Feel free to fork and submit pull requests, as we are always looking for improvements from the community.
+
+##Support
+
+ - Swift 2.x
+ - iOS 8.0
+ - tvOS 9.0
+ - watchOS (undefined deployment target)
+ - macOS (undefined deployment target)
+ - Extension friendly
+ - Tests only run against iOS 9 (latest) and tvOS 9 (latest)
+
+##Installation
+PSOperations supports multiple methods for installing the library in a project.
+
+###CocoaPods
+[CocoaPods](http://cocoapods.org) is a dependency manager for Objective-C, which automates and simplifies the process of using 3rd-party libraries like PSOperations in your projects.
+
+ You can install it with the following command:
+
+```bash
+$ gem install cocoapods
+```
+
+To integrate PSOperations into your Xcode project using CocoaPods, specify it in your `Podfile`:
+
+```ruby
+source 'https://github.com/CocoaPods/Specs.git'
+platform :ios, '8.0'
+
+target 'TargetName' do
+pod 'PSOperations', '~> 2.3'
+end
+```
+
+If you want to use Health Capabilities:
+```ruby
+pod 'PSOperations/Health', '~> 2.3'
+```
+
+if you want to use Pass Capabilities:
+```ruby
+pod 'PSOperations/Passbook', '~> 2.3'
+```
+
+Then, run the following command:
+
+```bash
+$ pod install
+```
+
+###Carthage
+[Carthage](https://github.com/Carthage/Carthage) is a decentralized dependency manager that builds your dependencies and provides you with binary frameworks.
+
+You can install Carthage with [Homebrew](http://brew.sh/) using the following command:
+
+```bash
+$ brew update
+$ brew install carthage
+```
+
+To integrate PSOperations into your Xcode project using Carthage, specify it in your `Cartfile`:
+
+```ogdl
+github "pluralsight/PSOperations"
+```
+
+Run `carthage` to build the framework and drag the built `PSOperations.framework` into your Xcode project. Optionally you can add `PSOperationsHealth.framework` and `PSOperationsPassbook.framework`
+
+##Getting started
+
+Don't forget to import!
+```
+import PSOperations
+```
+
+If you are using the HealthCapability or PassbookCapability you'll need to import them separately:
+
+```
+import PSOperationsHealth
+import PSOperationsPassbook
+```
+
+These features need to be in a separate framework otherwise they may cause App Store review rejection for importing `HealthKit` or `PassKit` but not actually using them.
+
+#### Create a Queue
+The OperationQueue is the heartbeat and is a subclass of NSOperationQueue:
+```
+let operationQueue = OperationQueue()
+```
+
+####Create an Operation
+`Operation` is a subclass of `NSOperation`. Like `NSOperation` it doesn't do much. But PSOperations provides a few helpful subclasses such as:
+```
+BlockOperation
+GroupOperation
+URLSessionTaskOperation
+LocationOperation
+DelayOperation
+```
+
+Here is a quick example:
+```
+let blockOperation = BlockOperation {
+	print("perform operation")
+}
+
+operationQueue.addOperation(blockOperation)
+```
+
+####Observe an Operation
+`Operation` instances can be observed for starting, cancelling, finishing and producing new operations with the `OperationObserver` protocol.
+
+PSOperations provide a couple of types that implement the protocol:
+```
+BlockObserver
+TimeoutObserver
+```
+
+Here is a quick example:
+```
+let blockOperation = BlockOperation {
+	print("perform operation")
+}
+
+let finishObserver = BlockObserver { operation, error in        
+	print("operation finished! \(error)")
+}
+
+blockOperation.addObserver(finishObserver)
+
+operationQueue.addOperation(blockOperation)
+```
+
+####Set Conditions on an Operation
+`Operation` instances can have conditions required to be met in order to execute using the `OperationCondition` protocol.
+
+PSOperations provide a several types that implement the protocol:
+```
+SilentCondition
+NegatedCondition
+NoCancelledDependencies
+MutuallyExclusive
+ReachabilityCondition
+Capability
+```
+
+Here is a quick example:
+```
+let blockOperation = BlockOperation {
+	print("perform operation")
+}
+
+let dependentOperation = BlockOperation {
+	print("working away")
+}
+                dependentOperation.addCondition(NoCancelledDependencies())
+dependentOperation.addDependency(blockOperation)
+
+operationQueue.addOperation(blockOperation)
+operationQueue.addOperation(dependentOperation)
+```
+
+if `blockOperation` is cancelled, `dependentOperation` will not execute.
+
+####Set Capabilities on an Operation
+A `CapabilityType` is used by the `Capability` condition and allows you to easily view the authorization state and request the authorization of certain capabilities within Apple's ecosystem. i.e. Calendar, Photos, iCloud, Location, and Push Notification.
+
+Here is a quick example:
+```
+let blockOperation = BlockOperation {
+	print("perform operation")
+}
+
+
+let calendarCapability = Capability(Photos())
+        
+blockOperation.addCondition(calendarCapability)
+
+operationQueue.addOperation(blockOperation)
+```
+
+This operation requires access to Photos and will request access to them if needed.
+
+####Going custom
+The examples above provide simple jobs but PSOperations can be involved in many parts of your application. Here is a custom `UIStoryboardSegue` that leverages the power of PSOperations. The segue is retained until an operation is completed. This is a generic `OperationSegue` that will run any given operation. One use case for this might be an authentication operation that ensures a user is authenticated before preceding with the segue. The authentication operation could even present authentication UI if needed.
+
+```
+class OperationSegue: UIStoryboardSegue {
+    
+    var operation: Operation?
+    var segueCompletion: ((success: Bool) -> Void)?
+    
+    override func perform() {        
+        if let operation = operation {
+            let opQ = OperationQueue()
+            var retainedSelf: OperationSegue? = self
+            
+            let completionObserver = BlockObserver {
+                op, errors in
+                
+                dispatch_async_on_main {
+                    defer {
+                        retainedSelf = nil
+                    }
+                    
+                    let success = errors.count == 0 && !op.cancelled
+                    
+                    if let completion = retainedSelf?.segueCompletion {
+                        completion(success: success)
+                    }
+                    
+                    if success {
+                        retainedSelf?.finish()
+                    }
+                }
+            }
+            
+            operation.addObserver(completionObserver)
+            opQ.addOperation(operation)
+        } else {
+            finish()
+        }
+    }
+    
+    func finish() {
+        super.perform()
+    }
+}
+
+```
+
+##Contribute
+
+
+Feel free to submit pull requests, as we are always looking for improvements from the community.
+
+##WWDC Differences
 
 Differences from the first version of the WWDC sample code:
-* Canceling operations would not work.
-* Canceling functions are slightly more friendly.
-* Negated Condition would not negate.
-* Unit tests!
+
+ - Canceling operations would not work.
+ - Canceling functions are slightly more friendly.
+ - Negated Condition would not negate.
+ - Unit tests!
 
 Differences from the second version of the WWDC sample code:
-* Sometimes canceling wouldn't work correctly in iOS 8.4. The finished override wasn't being called during cancel. We have fixed this to work in both iOS 8.4 and iOS 9.0.
-* Canceling functions are slightly more friendly.
-* Unit tests!
+
+ - Sometimes canceling wouldn't work correctly in iOS 8.4. The finished override wasn't being called during cancel. We have fixed this to work in both iOS 8.4 and iOS 9.0.
+ - Canceling functions are slightly more friendly.
+ - Unit tests!
 
 A difference from the WWDC Sample code worth mentioning:
-* When conditions are evaluated and they fail the associated operation is cancelled. The operation still goes through the same flow otherwise, only now it will be marked as cancelled.
+ 
+ - When conditions are evaluated and they fail the associated operation is cancelled. The operation still goes through the same flow otherwise, only now it will be marked as cancelled.

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,5 @@
+language: objective-c
+osx_image: xcode8
+script: 
+ - xcodebuild test -project PSOperations.xcodeproj -scheme PSOperations -destination 'platform=iOS Simulator,name=iPhone 6s' -destination 'platform=tvOS Simulator,name=Apple TV 1080p'
+ - xcodebuild test -project PSOperations.xcodeproj -scheme PSOperationsAppForTests -destination 'platform=iOS Simulator,name=iPhone 6s'


### PR DESCRIPTION
I am trying to prepare some of mine projects that adopts Advanced Operation code to Swift 3.0, the swift3 branch doesn't seems to work. So I tried the migration, based on pluralsight / PSOperation / master, using Swift 3.0 converter in Xcode 8.0 beta 3 and manual fixes.

Code builds in Xcode 8.0 beta 3, not yet tested in real projects.