### PR TITLE
WIP: Simplifying Operation.swift

### DIFF
--- a/PSOperations.xcodeproj/project.pbxproj
+++ b/PSOperations.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		FD85501F1D2D8E0E00162079 /* HealthCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8550191D2D8D3400162079 /* HealthCapability.swift */; };
 		FD8550211D2D8E2200162079 /* PassbookCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8550151D2D8D1D00162079 /* PassbookCapability.swift */; };
 		FD8550561D2D90A700162079 /* PSOperations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D9B430E1B6A92ED008F7F18 /* PSOperations.framework */; };
+		FD9362F5207C6D49002BB144 /* OperationQueueDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9362F4207C6D49002BB144 /* OperationQueueDelegate.swift */; };
 		FDB1BBBE1B8D67CB00FB9D7A /* NSLock+Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB1BBBD1B8D67CB00FB9D7A /* NSLock+Operations.swift */; };
 		FDB1E8F21BBC2B08006BC157 /* OperationConditionResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB1E8F11BBC2B08006BC157 /* OperationConditionResultTests.swift */; };
 		FDC6C5291BBCDDC9008FB96E /* URLSessionTaskOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC6C5281BBCDDC9008FB96E /* URLSessionTaskOperationTests.swift */; };
@@ -160,6 +161,7 @@
 		FD8550111D2D8CC100162079 /* PSOperationsPassbook.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PSOperationsPassbook.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD8550151D2D8D1D00162079 /* PassbookCapability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PassbookCapability.swift; path = PSOperationsPassbook/PassbookCapability.swift; sourceTree = "<group>"; };
 		FD8550191D2D8D3400162079 /* HealthCapability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HealthCapability.swift; path = PSOperationsHealth/HealthCapability.swift; sourceTree = SOURCE_ROOT; };
+		FD9362F4207C6D49002BB144 /* OperationQueueDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationQueueDelegate.swift; sourceTree = "<group>"; };
 		FDB1BBBD1B8D67CB00FB9D7A /* NSLock+Operations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSLock+Operations.swift"; sourceTree = "<group>"; };
 		FDB1E8F11BBC2B08006BC157 /* OperationConditionResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperationConditionResultTests.swift; sourceTree = "<group>"; };
 		FDC6C5281BBCDDC9008FB96E /* URLSessionTaskOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionTaskOperationTests.swift; sourceTree = "<group>"; };
@@ -302,6 +304,7 @@
 			children = (
 				1D9B432B1B6A934A008F7F18 /* ExclusivityController.swift */,
 				1D9B432A1B6A934A008F7F18 /* OperationQueue.swift */,
+				FD9362F4207C6D49002BB144 /* OperationQueueDelegate.swift */,
 			);
 			name = "Operation Queue";
 			sourceTree = "<group>";
@@ -715,6 +718,7 @@
 				1D9B43491B6A934A008F7F18 /* OperationQueue.swift in Sources */,
 				FD7564EB1EFDBB79006C2C45 /* State.swift in Sources */,
 				1D9B434E1B6A934A008F7F18 /* URLSessionTaskOperation.swift in Sources */,
+				FD9362F5207C6D49002BB144 /* OperationQueueDelegate.swift in Sources */,
 				1D9B43511B6A934A008F7F18 /* OperationObserver.swift in Sources */,
 				1D9B43641B6A934A008F7F18 /* NSOperation+Operations.swift in Sources */,
 				1D2DE5F51F55D1EE0080FF4F /* QualityOfService+.swift in Sources */,

--- a/PSOperations.xcodeproj/project.pbxproj
+++ b/PSOperations.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		FD19C9DD1C440293005D0F07 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FD19C9DB1C440293005D0F07 /* LaunchScreen.storyboard */; };
 		FD19C9E81C440293005D0F07 /* PSOperationsAppForTestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD19C9E71C440293005D0F07 /* PSOperationsAppForTestsTests.swift */; };
 		FD39C29E1B8B5F090092008B /* PSOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B436D1B6A942C008F7F18 /* PSOperationsTests.swift */; };
+		FD6B172D20853D390071F496 /* PSOperationsPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6B172C20853D390071F496 /* PSOperationsPerformanceTests.swift */; };
 		FD7564EB1EFDBB79006C2C45 /* State.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD7564EA1EFDBB79006C2C45 /* State.swift */; };
 		FD85501D1D2D8D9800162079 /* PSOperations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D9B430E1B6A92ED008F7F18 /* PSOperations.framework */; };
 		FD85501F1D2D8E0E00162079 /* HealthCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8550191D2D8D3400162079 /* HealthCapability.swift */; };
@@ -156,6 +157,7 @@
 		FD19C9E31C440293005D0F07 /* PSOperationsAppForTestsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PSOperationsAppForTestsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD19C9E71C440293005D0F07 /* PSOperationsAppForTestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PSOperationsAppForTestsTests.swift; sourceTree = "<group>"; };
 		FD19C9E91C440293005D0F07 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FD6B172C20853D390071F496 /* PSOperationsPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PSOperationsPerformanceTests.swift; sourceTree = "<group>"; };
 		FD7564EA1EFDBB79006C2C45 /* State.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = State.swift; sourceTree = "<group>"; };
 		FD854FDF1D2D8CAB00162079 /* PSOperationsHealth.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PSOperationsHealth.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD8550111D2D8CC100162079 /* PSOperationsPassbook.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PSOperationsPassbook.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -286,6 +288,7 @@
 				FDC6C5281BBCDDC9008FB96E /* URLSessionTaskOperationTests.swift */,
 				FDB1E8F11BBC2B08006BC157 /* OperationConditionResultTests.swift */,
 				1D9B436D1B6A942C008F7F18 /* PSOperationsTests.swift */,
+				FD6B172C20853D390071F496 /* PSOperationsPerformanceTests.swift */,
 				1D9B431E1B6A92ED008F7F18 /* Supporting Files */,
 			);
 			path = PSOperationsTests;
@@ -761,6 +764,7 @@
 				FDB1E8F21BBC2B08006BC157 /* OperationConditionResultTests.swift in Sources */,
 				FDC6C52C1BBD6447008FB96E /* OperationErrorCodeTests.swift in Sources */,
 				FD39C29E1B8B5F090092008B /* PSOperationsTests.swift in Sources */,
+				FD6B172D20853D390071F496 /* PSOperationsPerformanceTests.swift in Sources */,
 				FDC6C5291BBCDDC9008FB96E /* URLSessionTaskOperationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PSOperations.xcodeproj/project.pbxproj
+++ b/PSOperations.xcodeproj/project.pbxproj
@@ -599,7 +599,7 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = Pluralsight;
 				TargetAttributes = {
 					1D9B430D1B6A92ED008F7F18 = {
@@ -854,12 +854,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -893,6 +895,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -911,12 +914,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -941,7 +946,8 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -968,9 +974,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -995,8 +998,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -1011,9 +1012,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.pluralsight.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos macosx watchsimulator watchos";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -1026,8 +1024,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.pluralsight.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos macosx watchsimulator watchos";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -1049,9 +1045,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -1075,8 +1068,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -1093,8 +1084,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pluralsight.PSOperationsAppForTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1109,8 +1098,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pluralsight.PSOperationsAppForTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1125,8 +1112,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pluralsight.PSOperationsAppForTestsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PSOperationsAppForTests.app/PSOperationsAppForTests";
 			};
 			name = Debug;
@@ -1140,8 +1125,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pluralsight.PSOperationsAppForTestsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PSOperationsAppForTests.app/PSOperationsAppForTests";
 			};
 			name = Release;
@@ -1164,9 +1147,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -1190,8 +1170,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -1215,9 +1193,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -1241,8 +1216,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};

--- a/PSOperations.xcodeproj/project.pbxproj
+++ b/PSOperations.xcodeproj/project.pbxproj
@@ -45,7 +45,6 @@
 		55AE64DC1BC1C7E50097F4A5 /* PushCapability-OSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64DB1BC1C7E50097F4A5 /* PushCapability-OSX.swift */; };
 		55AE64DE1BC1DCF50097F4A5 /* UserNotificationCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64DD1BC1DCF50097F4A5 /* UserNotificationCapability.swift */; };
 		775C7EF5205718C30091A21F /* PSOperations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D9B430E1B6A92ED008F7F18 /* PSOperations.framework */; };
-		775C7EF7205718C30091A21F /* PSOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D9B43131B6A92ED008F7F18 /* PSOperations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		775C7EFE2057191B0091A21F /* CalendarCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64C61BC173100097F4A5 /* CalendarCapability.swift */; };
 		FD19C9D31C440293005D0F07 /* PSOperationsTestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD19C9D21C440293005D0F07 /* PSOperationsTestAppDelegate.swift */; };
 		FD19C9D51C440293005D0F07 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD19C9D41C440293005D0F07 /* ViewController.swift */; };
@@ -55,8 +54,6 @@
 		FD19C9E81C440293005D0F07 /* PSOperationsAppForTestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD19C9E71C440293005D0F07 /* PSOperationsAppForTestsTests.swift */; };
 		FD39C29E1B8B5F090092008B /* PSOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B436D1B6A942C008F7F18 /* PSOperationsTests.swift */; };
 		FD7564EB1EFDBB79006C2C45 /* State.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD7564EA1EFDBB79006C2C45 /* State.swift */; };
-		FD854FDA1D2D8CAB00162079 /* PSOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D9B43131B6A92ED008F7F18 /* PSOperations.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FD85500C1D2D8CC100162079 /* PSOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D9B43131B6A92ED008F7F18 /* PSOperations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FD85501D1D2D8D9800162079 /* PSOperations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D9B430E1B6A92ED008F7F18 /* PSOperations.framework */; };
 		FD85501F1D2D8E0E00162079 /* HealthCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8550191D2D8D3400162079 /* HealthCapability.swift */; };
 		FD8550211D2D8E2200162079 /* PassbookCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8550151D2D8D1D00162079 /* PassbookCapability.swift */; };
@@ -65,6 +62,7 @@
 		FDB1E8F21BBC2B08006BC157 /* OperationConditionResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB1E8F11BBC2B08006BC157 /* OperationConditionResultTests.swift */; };
 		FDC6C5291BBCDDC9008FB96E /* URLSessionTaskOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC6C5281BBCDDC9008FB96E /* URLSessionTaskOperationTests.swift */; };
 		FDC6C52C1BBD6447008FB96E /* OperationErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC6C52B1BBD6447008FB96E /* OperationErrorCodeTests.swift */; };
+		FDDAE4C7207019C100CF7B0D /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDDAE4C6207019C100CF7B0D /* Atomic.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -166,6 +164,7 @@
 		FDB1E8F11BBC2B08006BC157 /* OperationConditionResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperationConditionResultTests.swift; sourceTree = "<group>"; };
 		FDC6C5281BBCDDC9008FB96E /* URLSessionTaskOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionTaskOperationTests.swift; sourceTree = "<group>"; };
 		FDC6C52B1BBD6447008FB96E /* OperationErrorCodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperationErrorCodeTests.swift; sourceTree = "<group>"; };
+		FDDAE4C6207019C100CF7B0D /* Atomic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -257,14 +256,13 @@
 		1D9B43101B6A92ED008F7F18 /* PSOperations */ = {
 			isa = PBXGroup;
 			children = (
-				1D9B43131B6A92ED008F7F18 /* PSOperations.h */,
-				1D9B43681B6A934F008F7F18 /* Operation Queue */,
-				1D9B43691B6A9375008F7F18 /* Operations */,
-				1D9B436A1B6A938F008F7F18 /* Observers */,
+				FDDAE4C52070196100CF7B0D /* Concurrency */,
 				1D9B436B1B6A93B0008F7F18 /* Conditions */,
 				1D9B436C1B6A93C9008F7F18 /* Convenience Extensions */,
+				1D9B436A1B6A938F008F7F18 /* Observers */,
+				1D9B43681B6A934F008F7F18 /* Operation Queue */,
+				1D9B43691B6A9375008F7F18 /* Operations */,
 				1D9B43111B6A92ED008F7F18 /* Supporting Files */,
-				1D57B1E41D919D38008333C7 /* Typealiases.swift */,
 			);
 			path = PSOperations;
 			sourceTree = "<group>";
@@ -273,6 +271,8 @@
 			isa = PBXGroup;
 			children = (
 				1D9B43121B6A92ED008F7F18 /* Info.plist */,
+				1D9B43131B6A92ED008F7F18 /* PSOperations.h */,
+				1D57B1E41D919D38008333C7 /* Typealiases.swift */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -300,8 +300,8 @@
 		1D9B43681B6A934F008F7F18 /* Operation Queue */ = {
 			isa = PBXGroup;
 			children = (
-				1D9B432A1B6A934A008F7F18 /* OperationQueue.swift */,
 				1D9B432B1B6A934A008F7F18 /* ExclusivityController.swift */,
+				1D9B432A1B6A934A008F7F18 /* OperationQueue.swift */,
 			);
 			name = "Operation Queue";
 			sourceTree = "<group>";
@@ -309,13 +309,13 @@
 		1D9B43691B6A9375008F7F18 /* Operations */ = {
 			isa = PBXGroup;
 			children = (
+				1D9B432D1B6A934A008F7F18 /* BlockOperation.swift */,
+				1D9B43311B6A934A008F7F18 /* DelayOperation.swift */,
+				1D9B432E1B6A934A008F7F18 /* GroupOperation.swift */,
+				1D9B43301B6A934A008F7F18 /* LocationOperation.swift */,
 				1D9B432C1B6A934A008F7F18 /* Operation.swift */,
 				FD7564EA1EFDBB79006C2C45 /* State.swift */,
-				1D9B432D1B6A934A008F7F18 /* BlockOperation.swift */,
-				1D9B432E1B6A934A008F7F18 /* GroupOperation.swift */,
 				1D9B432F1B6A934A008F7F18 /* URLSessionTaskOperation.swift */,
-				1D9B43301B6A934A008F7F18 /* LocationOperation.swift */,
-				1D9B43311B6A934A008F7F18 /* DelayOperation.swift */,
 			);
 			name = Operations;
 			sourceTree = "<group>";
@@ -323,8 +323,8 @@
 		1D9B436A1B6A938F008F7F18 /* Observers */ = {
 			isa = PBXGroup;
 			children = (
-				1D9B43321B6A934A008F7F18 /* OperationObserver.swift */,
 				1D9B43331B6A934A008F7F18 /* BlockObserver.swift */,
+				1D9B43321B6A934A008F7F18 /* OperationObserver.swift */,
 				1D9B43341B6A934A008F7F18 /* TimeoutObserver.swift */,
 			);
 			name = Observers;
@@ -333,14 +333,14 @@
 		1D9B436B1B6A93B0008F7F18 /* Conditions */ = {
 			isa = PBXGroup;
 			children = (
-				1D9B43351B6A934A008F7F18 /* OperationErrors.swift */,
-				1D9B43361B6A934A008F7F18 /* OperationCondition.swift */,
-				1D9B43371B6A934A008F7F18 /* SilentCondition.swift */,
+				55AE64C51BC173000097F4A5 /* Capabilities */,
+				1D9B433A1B6A934A008F7F18 /* MutuallyExclusive.swift */,
 				1D9B43381B6A934A008F7F18 /* NegatedCondition.swift */,
 				1D9B43391B6A934A008F7F18 /* NoCancelledDependencies.swift */,
-				1D9B433A1B6A934A008F7F18 /* MutuallyExclusive.swift */,
+				1D9B43351B6A934A008F7F18 /* OperationErrors.swift */,
+				1D9B43361B6A934A008F7F18 /* OperationCondition.swift */,
 				1D9B433B1B6A934A008F7F18 /* ReachabilityCondition.swift */,
-				55AE64C51BC173000097F4A5 /* Capabilities */,
+				1D9B43371B6A934A008F7F18 /* SilentCondition.swift */,
 			);
 			name = Conditions;
 			sourceTree = "<group>";
@@ -349,11 +349,11 @@
 			isa = PBXGroup;
 			children = (
 				1D9B43441B6A934A008F7F18 /* Dictionary+Operations.swift */,
-				1D9B43451B6A934A008F7F18 /* NSOperation+Operations.swift */,
-				FDB1BBBD1B8D67CB00FB9D7A /* NSLock+Operations.swift */,
-				1D9B43471B6A934A008F7F18 /* UIUserNotifications+Operations.swift */,
-				1D2DE5F41F55D1EE0080FF4F /* QualityOfService+.swift */,
 				1D2DE6221F5600540080FF4F /* DispatchQueue+.swift */,
+				FDB1BBBD1B8D67CB00FB9D7A /* NSLock+Operations.swift */,
+				1D9B43451B6A934A008F7F18 /* NSOperation+Operations.swift */,
+				1D2DE5F41F55D1EE0080FF4F /* QualityOfService+.swift */,
+				1D9B43471B6A934A008F7F18 /* UIUserNotifications+Operations.swift */,
 			);
 			name = "Convenience Extensions";
 			sourceTree = "<group>";
@@ -421,6 +421,14 @@
 			name = PSOperationsPassbook;
 			sourceTree = "<group>";
 		};
+		FDDAE4C52070196100CF7B0D /* Concurrency */ = {
+			isa = PBXGroup;
+			children = (
+				FDDAE4C6207019C100CF7B0D /* Atomic.swift */,
+			);
+			name = Concurrency;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -436,7 +444,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				775C7EF7205718C30091A21F /* PSOperations.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -444,7 +451,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FD854FDA1D2D8CAB00162079 /* PSOperations.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -452,7 +458,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FD85500C1D2D8CC100162079 /* PSOperations.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -734,6 +739,7 @@
 				1D9B43571B6A934A008F7F18 /* NegatedCondition.swift in Sources */,
 				1D9B434D1B6A934A008F7F18 /* GroupOperation.swift in Sources */,
 				1D9B43501B6A934A008F7F18 /* DelayOperation.swift in Sources */,
+				FDDAE4C7207019C100CF7B0D /* Atomic.swift in Sources */,
 				55AE64D21BC180570097F4A5 /* LocationCapability-tvOS.swift in Sources */,
 				1D9B43541B6A934A008F7F18 /* OperationErrors.swift in Sources */,
 				1D9B43561B6A934A008F7F18 /* SilentCondition.swift in Sources */,

--- a/PSOperations.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/PSOperations.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/PSOperations.xcodeproj/xcshareddata/xcbaselines/1D9B43181B6A92ED008F7F18.xcbaseline/99194DE9-FF25-4970-ABB3-67D93688B1B4.plist
+++ b/PSOperations.xcodeproj/xcshareddata/xcbaselines/1D9B43181B6A92ED008F7F18.xcbaseline/99194DE9-FF25-4970-ABB3-67D93688B1B4.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>PSOperationsPerformanceTests</key>
+		<dict>
+			<key>testPSOperationPerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.23714</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/PSOperations.xcodeproj/xcshareddata/xcbaselines/1D9B43181B6A92ED008F7F18.xcbaseline/Info.plist
+++ b/PSOperations.xcodeproj/xcshareddata/xcbaselines/1D9B43181B6A92ED008F7F18.xcbaseline/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>99194DE9-FF25-4970-ABB3-67D93688B1B4</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>100</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Intel Core i7</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2900</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>modelCode</key>
+				<string>MacBookPro14,3</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>4</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone10,3</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperations.xcscheme
+++ b/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperations.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,9 +40,9 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      enableASanStackUseAfterReturn = "YES"
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -71,7 +71,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsAppForTests.xcscheme
+++ b/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsAppForTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -56,7 +55,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsCalendar.xcscheme
+++ b/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsCalendar.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -37,7 +36,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsHealth.xcscheme
+++ b/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsHealth.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -37,7 +36,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsPassbook.xcscheme
+++ b/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsPassbook.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -37,7 +36,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/PSOperations/Atomic.swift
+++ b/PSOperations/Atomic.swift
@@ -1,0 +1,55 @@
+//
+//  Atomic.swift
+//  PSOperations
+//
+//  Created by Matt McMurry on 3/31/18.
+//  Copyright © 2018 Pluralsight. All rights reserved.
+//
+
+import Foundation
+
+public final class Atomic<T> {
+    
+    private var _value: T
+    private let lock = NSLock()
+    
+    public var value: T {
+        get {
+            lock.lock()
+            let value = _value
+            lock.unlock()
+            return value
+        }
+        set {
+            lock.lock()
+            _value = newValue
+            lock.unlock()
+        }
+    }
+    
+    init(value: T) {
+        _value = value
+    }
+    
+    public func modify(_ modify: (inout T) -> ()) {
+        lock.lock()
+        modify(&_value)
+        lock.unlock()
+    }
+    
+    @discardableResult
+    public func swap(_ value: T) -> T {
+        lock.lock()
+        let current = _value
+        _value = value
+        lock.unlock()
+        return current
+    }
+    
+    public func with<U>(_ value: (T) -> U) -> U {
+        lock.lock()
+        let returnValue = value(_value)
+        lock.unlock()
+        return returnValue
+    }
+}

--- a/PSOperations/BlockOperation.swift
+++ b/PSOperations/BlockOperation.swift
@@ -1,10 +1,10 @@
 /*
-Copyright (C) 2015 Apple Inc. All Rights Reserved.
-See LICENSE.txt for this sample’s licensing information
-
-Abstract:
-This code shows how to create a simple subclass of Operation.
-*/
+ Copyright (C) 2015 Apple Inc. All Rights Reserved.
+ See LICENSE.txt for this sample’s licensing information
+ 
+ Abstract:
+ This code shows how to create a simple subclass of Operation.
+ */
 
 import Foundation
 
@@ -16,28 +16,44 @@ open class BlockOperation: Operation {
     fileprivate let block: OperationBlock?
     
     /**
-        The designated initializer.
-        
-        - parameter block: The closure to run when the operation executes. This 
-            closure will be run on an arbitrary queue. The parameter passed to the
-            block **MUST** be invoked by your code, or else the `BlockOperation`
-            will never finish executing. If this parameter is `nil`, the operation
-            will immediately finish.
-    */
+     The designated initializer.
+     
+     - parameter block: The closure to run when the operation executes. This
+     closure will be run on an arbitrary queue. The parameter passed to the
+     block **MUST** be invoked by your code, or else the `BlockOperation`
+     will never finish executing. If this parameter is `nil`, the operation
+     will immediately finish.
+     */
     public init(block: OperationBlock? = nil) {
         self.block = block
         super.init()
     }
     
     /**
-        A convenience initializer to execute a block on the main queue.
-        
-        - parameter mainQueueBlock: The block to execute on the main queue. Note
-            that this block does not have a "continuation" block to execute (unlike
-            the designated initializer). The operation will be automatically ended 
-            after the `mainQueueBlock` is executed.
-    */
-    public convenience init(mainQueueBlock: @escaping ()->()) {
+     A convenience initializer to execute a block of code.
+     
+     - parameter block: The block to execute. Note
+     that this block does not have a "continuation" block to execute (unlike
+     the designated initializer). The operation will be automatically ended
+     after the `block` is executed.
+     */
+    public convenience init(block: @escaping () -> Void) {
+        self.init { continuation in
+            block()
+            continuation()
+        }
+    }
+    
+    /**
+     A convenience initializer to execute a block on the main queue.
+     
+     - parameter mainQueueBlock: The block to execute on the main queue. Note
+     that this block does not have a "continuation" block to execute (unlike
+     the designated initializer). The operation will be automatically ended
+     after the `mainQueueBlock` is executed.
+     */
+    @available(*, deprecated: 1.0, message: "This initializer breaks QOS, please use the main initializer. If you want to execute on the main thread you still can yourself within the closure. This initializer will be removed in a future version of PSOperations")
+    public convenience init(mainQueueBlock: @escaping () -> Void) {
         self.init(block: { continuation in
             DispatchQueue.main.async {
                 mainQueueBlock()

--- a/PSOperations/ExclusivityController.swift
+++ b/PSOperations/ExclusivityController.swift
@@ -20,12 +20,7 @@ class ExclusivityController {
     fileprivate let serialQueue = DispatchQueue(label: "Operations.ExclusivityController", attributes: [])
     fileprivate var operations: [String: [Operation]] = [:]
     
-    fileprivate init() {
-        /*
-            A private initializer effectively prevents any other part of the app
-            from accidentally creating an instance.
-        */
-    }
+    fileprivate init() { }
     
     /// Registers an operation as being mutually exclusive
     func addOperation(_ operation: Operation, categories: [String]) {
@@ -67,10 +62,10 @@ class ExclusivityController {
     
     fileprivate func noqueue_removeOperation(_ operation: Operation, category: String) {
         let matchingOperations = operations[category]
-
+        
         if var operationsWithThisCategory = matchingOperations,
            let index = operationsWithThisCategory.index(of: operation) {
-
+            
             operationsWithThisCategory.remove(at: index)
             operations[category] = operationsWithThisCategory
         }

--- a/PSOperations/GroupOperation.swift
+++ b/PSOperations/GroupOperation.swift
@@ -43,9 +43,6 @@ open class GroupOperation: Operation {
         }
     }
     
-    
-    
-    
     public convenience init(operations: Foundation.Operation...) {
         self.init(operations: operations)
     }

--- a/PSOperations/OperationCondition.swift
+++ b/PSOperations/OperationCondition.swift
@@ -96,7 +96,7 @@ struct OperationConditionEvaluator {
         // After all the conditions have evaluated, this block will execute.
         conditionGroup.notify(queue: DispatchQueue.global(qos: DispatchQoS.QoSClass.default)) {
             // Aggregate the errors that occurred, in order.
-            var failures = results.flatMap { $0?.error }
+            var failures = results.compactMap { $0?.error }
             
             /*
                 If any of the conditions caused this operation to be cancelled, 

--- a/PSOperations/OperationQueue.swift
+++ b/PSOperations/OperationQueue.swift
@@ -9,23 +9,8 @@ This file contains an NSOperationQueue subclass.
 import Foundation
 
 /**
-    The delegate of an `OperationQueue` can respond to `Operation` lifecycle
-    events by implementing these methods.
-
-    In general, implementing `OperationQueueDelegate` is not necessary; you would
-    want to use an `OperationObserver` instead. However, there are a couple of
-    situations where using `OperationQueueDelegate` can lead to simpler code.
-    For example, `GroupOperation` is the delegate of its own internal
-    `OperationQueue` and uses it to manage dependencies.
-*/
-@objc public protocol OperationQueueDelegate: NSObjectProtocol {
-    @objc optional func operationQueue(_ operationQueue: OperationQueue, willAddOperation operation: Foundation.Operation)
-    @objc optional func operationQueue(_ operationQueue: OperationQueue, operationDidFinish operation: Foundation.Operation, withErrors errors: [NSError])
-}
-
-/**
     `OperationQueue` is an `NSOperationQueue` subclass that implements a large
-    number of "extra features" related to the `Operation` class:
+     number of "extra features" related to the `Operation` class:
     
     - Notifying a delegate of all operation completion
     - Extracting generated dependencies from operation conditions
@@ -34,7 +19,7 @@ import Foundation
 open class OperationQueue: Foundation.OperationQueue {
     open weak var delegate: OperationQueueDelegate?
     
-    override open  func addOperation(_ operation: Foundation.Operation) {
+    override open func addOperation(_ operation: Foundation.Operation) {
         if let op = operation as? Operation {
             
             // Set up a `BlockObserver` to invoke the `OperationQueueDelegate` method.

--- a/PSOperations/OperationQueue.swift
+++ b/PSOperations/OperationQueue.swift
@@ -55,11 +55,10 @@ open class OperationQueue: Foundation.OperationQueue {
             let dependencies = op.conditions.flatMap {
                 $0.dependencyForOperation(op)
             }
-                
+            
             for dependency in dependencies {
                 op.addDependency(dependency)
-
-                self.addOperation(dependency)
+                addOperation(dependency)
             }
             
             /*

--- a/PSOperations/OperationQueue.swift
+++ b/PSOperations/OperationQueue.swift
@@ -52,7 +52,7 @@ open class OperationQueue: Foundation.OperationQueue {
             op.addObserver(delegate)
             
             // Extract any dependencies needed by this operation.
-            let dependencies = op.conditions.flatMap {
+            let dependencies = op.conditions.compactMap {
                 $0.dependencyForOperation(op)
             }
             
@@ -65,7 +65,7 @@ open class OperationQueue: Foundation.OperationQueue {
                 With condition dependencies added, we can now see if this needs
                 dependencies to enforce mutual exclusivity.
             */
-            let concurrencyCategories: [String] = op.conditions.flatMap { condition in
+            let concurrencyCategories: [String] = op.conditions.compactMap { condition in
                 guard type(of: condition).isMutuallyExclusive else { return nil }
                 
                 return "\(type(of: condition))"

--- a/PSOperations/OperationQueueDelegate.swift
+++ b/PSOperations/OperationQueueDelegate.swift
@@ -1,0 +1,24 @@
+//
+//  OperationQueueDelegate.swift
+//  PSOperations
+//
+//  Created by Matt McMurry on 4/9/18.
+//  Copyright © 2018 Pluralsight. All rights reserved.
+//
+
+import Foundation
+
+/**
+ The delegate of an `OperationQueue` can respond to `Operation` lifecycle
+ events by implementing these methods.
+ 
+ In general, implementing `OperationQueueDelegate` is not necessary; you would
+ want to use an `OperationObserver` instead. However, there are a couple of
+ situations where using `OperationQueueDelegate` can lead to simpler code.
+ For example, `GroupOperation` is the delegate of its own internal
+ `OperationQueue` and uses it to manage dependencies.
+ */
+@objc public protocol OperationQueueDelegate: NSObjectProtocol {
+    @objc optional func operationQueue(_ operationQueue: OperationQueue, willAddOperation operation: Foundation.Operation)
+    @objc optional func operationQueue(_ operationQueue: OperationQueue, operationDidFinish operation: Foundation.Operation, withErrors errors: [NSError])
+}

--- a/PSOperations/State.swift
+++ b/PSOperations/State.swift
@@ -42,19 +42,26 @@ internal enum State: Int, Comparable {
     
     func canTransitionToState(_ target: State, operationIsCancelled cancelled: Bool) -> Bool {
         switch (self, target) {
+        //to pending
         case (.initialized, .pending):
             return true
-        case (.pending, .evaluatingConditions):
-            return true
-        case (.pending, .finished): // where cancelled:
+        //to ready
+        case (.initialized, .ready) where cancelled:
             return true
         case (.pending, .ready):
             return true
         case (.evaluatingConditions, .ready):
             return true
-        case (.evaluatingConditions, .finished): // where cancelled:
+        //to evaluatingConditions
+        case (.pending, .evaluatingConditions):
             return true
+        //to executing
         case (.ready, .executing):
+            return true
+        //to finished
+        case (.pending, .finished):
+            return true
+        case (.evaluatingConditions, .finished):
             return true
         case (.ready, .finished):
             return true

--- a/PSOperations/State.swift
+++ b/PSOperations/State.swift
@@ -37,12 +37,6 @@ internal enum State: Int, Comparable {
     /// The `Operation` is executing.
     case executing
     
-    /**
-     Execution of the `Operation` has finished, but it has not yet notified
-     the queue of this.
-     */
-    case finishing
-    
     /// The `Operation` has finished executing.
     case finished
     
@@ -52,19 +46,19 @@ internal enum State: Int, Comparable {
             return true
         case (.pending, .evaluatingConditions):
             return true
-        case (.pending, .finishing) where cancelled:
+        case (.pending, .finished): // where cancelled:
             return true
         case (.pending, .ready):
             return true
         case (.evaluatingConditions, .ready):
             return true
+        case (.evaluatingConditions, .finished): // where cancelled:
+            return true
         case (.ready, .executing):
             return true
-        case (.ready, .finishing):
+        case (.ready, .finished):
             return true
-        case (.executing, .finishing):
-            return true
-        case (.finishing, .finished):
+        case (.executing, .finished):
             return true
         default:
             return false

--- a/PSOperationsTests/PSOperationsPerformanceTests.swift
+++ b/PSOperationsTests/PSOperationsPerformanceTests.swift
@@ -1,0 +1,31 @@
+//
+//  PSOperationsPerformanceTests.swift
+//  PSOperationsTests
+//
+//  Created by Matt McMurry on 4/16/18.
+//  Copyright © 2018 Pluralsight. All rights reserved.
+//
+
+@testable import PSOperations
+import XCTest
+
+class PSOperationsPerformanceTests: XCTestCase {
+
+    func testPSOperationPerformance() {
+        let queue = PSOperationQueue()
+        queue.isSuspended = true
+        measure {
+            for i in 0...1000 {
+                let exp = expectation(description: "op #\(i)")
+                let operation = PSBlockOperation(block: {
+                    exp.fulfill()
+                })
+                
+                queue.addOperation(operation)
+            }
+            
+            queue.isSuspended = false
+            waitForExpectations(timeout: 50, handler: nil)
+        }
+    }
+}


### PR DESCRIPTION
PSOperations has always been a great framework. It was introduced to us as Advanced Operations from WWDC. From the beginning it helped a lot, however, we ran into bugs, the bugs led to unideal fixes that caused excessive locking of resource to ensure things could only happen in order. I've long wanted to reduce the craziness of the locking and have a clean approach to Operation.swift. This branch is named threading-cleanup because it focuses on the need to remove Locks RecursiveLocks and DispatchQueues. Other general cleanup and simplification will be included as well.

### Goals

🔴 Make `isExecuting`, `isFinished`, `isReady`, `isCancelled` stored properties and whose backing values are only updated during `state` changes. This will make these properties always avaliable. `isReady` will have a slightly different implementation, while it will always be able to return a value (never stuck behind a lock), it will occasionaly be responsible for altering state because of the greater `NSOperation` system especially in regards to dependencies.
✅ Rid the class of the `NSRecursiveLock`. This can be confusing to understand and an engineer at Apple has suggested that we try hard to avoid it.
✅ When locking a resource it needs to be less complicated right now at the top of several methods we have code like this: ``` stateAccess.lock(); defer { stateAccess.unlock } ```. This code can be hard to understand as to when exactly the unlock may occur.
✅ Remove observing our own `isReady` property (KVO). I alluded to the solution in the first goal. Observing our own `isReady` has always been a pain we've had to carefully navigate because when the observer function is fired we have to be careful to not trigger it within the body of that function thus causing infinite recursive. Several hours has been spent around this in the past.
✅ Simplify cancelling. In the very original implentation cancel was part of state, however, that didn't pair well with how `NSOperation` works. In a follow-up implementation cancel was separated from from state and worked for the most part but still needed to work. While cancel needs to be separate from state it is still tightly connected to state. Cancelling should be tied up with state changes but not be a state itself. Making this change will reduce locks.
✅ Make user implemented code like `finished` and `execute` run outside the lock. These operations are not state altering and show not be run in a locked case.

### Other notes:

✅ In the current implementation the state `State.finishing` is short lived and because of the lock, inaccessible. I'm going to remove it.
✅ In the current implementation `cancel(...)` calls `finish(...)` (as it should), `evaluateConditions()` advances to `State.ready` and then if it has errors calls `finish(...)` because of this `main()` does not need to be called as all it will do is execute `finish(...)` so if `evaluateConditions()` fails we do not need to become ready first, we can advance directly from `State.evaluateConditions` to `State.finished` and skip `main()` altogether. Not this is specifically around `evaluateConditions()` in the case that the operation has conditions. Calling `cancel(...)` otherwise, follows another path (i.e. `main()` may already be executing depending when you call `cancel(...)`)
✅ DispatchQueue is not an entirely safe way to make property thread-safe. I've introduce Atomic.swift which is backed by an `NSLock` and it will replace any queues that are being used to create thread-safe properties.