### PR TITLE
Moved LocationCapability and LocationOperation into their own podspec

### DIFF
--- a/PSOperations.podspec
+++ b/PSOperations.podspec
@@ -43,4 +43,9 @@ Pod::Spec.new do |s|
   		sb.source_files = "PSOperationsCalendar/*.swift"
   	end
   
+  	s.subspec "Location" do |sb|
+	  	sb.dependency 'PSOperations/Core'
+  		sb.source_files = "PSOperationsLocation/*.swift"
+  	end
+
 end

--- a/PSOperations.xcodeproj/project.pbxproj
+++ b/PSOperations.xcodeproj/project.pbxproj
@@ -20,7 +20,6 @@
 		1D9B434C1B6A934A008F7F18 /* BlockOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B432D1B6A934A008F7F18 /* BlockOperation.swift */; };
 		1D9B434D1B6A934A008F7F18 /* GroupOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B432E1B6A934A008F7F18 /* GroupOperation.swift */; };
 		1D9B434E1B6A934A008F7F18 /* URLSessionTaskOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B432F1B6A934A008F7F18 /* URLSessionTaskOperation.swift */; };
-		1D9B434F1B6A934A008F7F18 /* LocationOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B43301B6A934A008F7F18 /* LocationOperation.swift */; };
 		1D9B43501B6A934A008F7F18 /* DelayOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B43311B6A934A008F7F18 /* DelayOperation.swift */; };
 		1D9B43511B6A934A008F7F18 /* OperationObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B43321B6A934A008F7F18 /* OperationObserver.swift */; };
 		1D9B43521B6A934A008F7F18 /* BlockObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B43331B6A934A008F7F18 /* BlockObserver.swift */; };
@@ -37,16 +36,19 @@
 		1D9B43661B6A934A008F7F18 /* UIUserNotifications+Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B43471B6A934A008F7F18 /* UIUserNotifications+Operations.swift */; };
 		55AE64C41BC172ED0097F4A5 /* Capability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64C31BC172ED0097F4A5 /* Capability.swift */; };
 		55AE64C91BC1732D0097F4A5 /* PhotosCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64C81BC1732D0097F4A5 /* PhotosCapability.swift */; };
-		55AE64CD1BC1738D0097F4A5 /* LocationCapability-iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64CC1BC1738D0097F4A5 /* LocationCapability-iOS.swift */; };
 		55AE64CF1BC175190097F4A5 /* iCloudContainerCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64CE1BC175190097F4A5 /* iCloudContainerCapability.swift */; };
-		55AE64D21BC180570097F4A5 /* LocationCapability-tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64D11BC180570097F4A5 /* LocationCapability-tvOS.swift */; };
-		55AE64D41BC180650097F4A5 /* LocationCapability-OSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64D31BC180650097F4A5 /* LocationCapability-OSX.swift */; };
 		55AE64DA1BC1C7430097F4A5 /* PushCapability-iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64D91BC1C7430097F4A5 /* PushCapability-iOS.swift */; };
 		55AE64DC1BC1C7E50097F4A5 /* PushCapability-OSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64DB1BC1C7E50097F4A5 /* PushCapability-OSX.swift */; };
 		55AE64DE1BC1DCF50097F4A5 /* UserNotificationCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64DD1BC1DCF50097F4A5 /* UserNotificationCapability.swift */; };
 		775C7EF5205718C30091A21F /* PSOperations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D9B430E1B6A92ED008F7F18 /* PSOperations.framework */; };
 		775C7EF7205718C30091A21F /* PSOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D9B43131B6A92ED008F7F18 /* PSOperations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		775C7EFE2057191B0091A21F /* CalendarCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64C61BC173100097F4A5 /* CalendarCapability.swift */; };
+		A39DCF6F2091C808009DF08E /* PSOperations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D9B430E1B6A92ED008F7F18 /* PSOperations.framework */; };
+		A39DCF712091C808009DF08E /* PSOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D9B43131B6A92ED008F7F18 /* PSOperations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A39DCF782091C8B6009DF08E /* LocationOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B43301B6A934A008F7F18 /* LocationOperation.swift */; };
+		A39DCF792091C8B6009DF08E /* LocationCapability-iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64CC1BC1738D0097F4A5 /* LocationCapability-iOS.swift */; };
+		A39DCF7A2091C8B6009DF08E /* LocationCapability-tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64D11BC180570097F4A5 /* LocationCapability-tvOS.swift */; };
+		A39DCF7B2091C8B6009DF08E /* LocationCapability-OSX.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AE64D31BC180650097F4A5 /* LocationCapability-OSX.swift */; };
 		FD19C9D31C440293005D0F07 /* PSOperationsTestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD19C9D21C440293005D0F07 /* PSOperationsTestAppDelegate.swift */; };
 		FD19C9D51C440293005D0F07 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD19C9D41C440293005D0F07 /* ViewController.swift */; };
 		FD19C9D81C440293005D0F07 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FD19C9D61C440293005D0F07 /* Main.storyboard */; };
@@ -147,6 +149,7 @@
 		55AE64DB1BC1C7E50097F4A5 /* PushCapability-OSX.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PushCapability-OSX.swift"; sourceTree = "<group>"; };
 		55AE64DD1BC1DCF50097F4A5 /* UserNotificationCapability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNotificationCapability.swift; sourceTree = "<group>"; };
 		775C7EFC205718C30091A21F /* PSOperationsCalendar.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PSOperationsCalendar.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A39DCF762091C808009DF08E /* PSOperationsLocation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PSOperationsLocation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD19C9D01C440293005D0F07 /* PSOperationsAppForTests.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PSOperationsAppForTests.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD19C9D21C440293005D0F07 /* PSOperationsTestAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PSOperationsTestAppDelegate.swift; sourceTree = "<group>"; };
 		FD19C9D41C440293005D0F07 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -192,6 +195,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A39DCF6E2091C808009DF08E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A39DCF6F2091C808009DF08E /* PSOperations.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FD19C9CD1C440293005D0F07 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -231,6 +242,7 @@
 			children = (
 				1D9B43101B6A92ED008F7F18 /* PSOperations */,
 				775C7EF02057187A0091A21F /* PSOperationsCalendar */,
+				A39DCF6A2091C7CD009DF08E /* PSOperationsLocation */,
 				FD8550141D2D8CDF00162079 /* PSOperationsPassbook */,
 				FD8550131D2D8CCE00162079 /* PSOperationsHealth */,
 				1D9B431D1B6A92ED008F7F18 /* PSOperationsTests */,
@@ -250,6 +262,7 @@
 				FD854FDF1D2D8CAB00162079 /* PSOperationsHealth.framework */,
 				FD8550111D2D8CC100162079 /* PSOperationsPassbook.framework */,
 				775C7EFC205718C30091A21F /* PSOperationsCalendar.framework */,
+				A39DCF762091C808009DF08E /* PSOperationsLocation.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -314,7 +327,6 @@
 				1D9B432D1B6A934A008F7F18 /* BlockOperation.swift */,
 				1D9B432E1B6A934A008F7F18 /* GroupOperation.swift */,
 				1D9B432F1B6A934A008F7F18 /* URLSessionTaskOperation.swift */,
-				1D9B43301B6A934A008F7F18 /* LocationOperation.swift */,
 				1D9B43311B6A934A008F7F18 /* DelayOperation.swift */,
 			);
 			name = Operations;
@@ -363,9 +375,6 @@
 			children = (
 				55AE64C31BC172ED0097F4A5 /* Capability.swift */,
 				55AE64CE1BC175190097F4A5 /* iCloudContainerCapability.swift */,
-				55AE64CC1BC1738D0097F4A5 /* LocationCapability-iOS.swift */,
-				55AE64D11BC180570097F4A5 /* LocationCapability-tvOS.swift */,
-				55AE64D31BC180650097F4A5 /* LocationCapability-OSX.swift */,
 				55AE64C81BC1732D0097F4A5 /* PhotosCapability.swift */,
 				55AE64D91BC1C7430097F4A5 /* PushCapability-iOS.swift */,
 				55AE64DB1BC1C7E50097F4A5 /* PushCapability-OSX.swift */,
@@ -380,6 +389,17 @@
 				55AE64C61BC173100097F4A5 /* CalendarCapability.swift */,
 			);
 			path = PSOperationsCalendar;
+			sourceTree = "<group>";
+		};
+		A39DCF6A2091C7CD009DF08E /* PSOperationsLocation */ = {
+			isa = PBXGroup;
+			children = (
+				1D9B43301B6A934A008F7F18 /* LocationOperation.swift */,
+				55AE64CC1BC1738D0097F4A5 /* LocationCapability-iOS.swift */,
+				55AE64D11BC180570097F4A5 /* LocationCapability-tvOS.swift */,
+				55AE64D31BC180650097F4A5 /* LocationCapability-OSX.swift */,
+			);
+			path = PSOperationsLocation;
 			sourceTree = "<group>";
 		};
 		FD19C9D11C440293005D0F07 /* PSOperationsAppForTests */ = {
@@ -437,6 +457,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				775C7EF7205718C30091A21F /* PSOperations.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A39DCF702091C808009DF08E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A39DCF712091C808009DF08E /* PSOperations.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -511,6 +539,24 @@
 			name = PSOperationsCalendar;
 			productName = PSOperations;
 			productReference = 775C7EFC205718C30091A21F /* PSOperationsCalendar.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		A39DCF6B2091C808009DF08E /* PSOperationsLocation */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A39DCF732091C808009DF08E /* Build configuration list for PBXNativeTarget "PSOperationsLocation" */;
+			buildPhases = (
+				A39DCF6C2091C808009DF08E /* Sources */,
+				A39DCF6E2091C808009DF08E /* Frameworks */,
+				A39DCF702091C808009DF08E /* Headers */,
+				A39DCF722091C808009DF08E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = PSOperationsLocation;
+			productName = PSOperations;
+			productReference = A39DCF762091C808009DF08E /* PSOperationsLocation.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		FD19C9CF1C440293005D0F07 /* PSOperationsAppForTests */ = {
@@ -637,6 +683,7 @@
 			targets = (
 				1D9B430D1B6A92ED008F7F18 /* PSOperations */,
 				775C7EF1205718C30091A21F /* PSOperationsCalendar */,
+				A39DCF6B2091C808009DF08E /* PSOperationsLocation */,
 				FD854FAF1D2D8CAB00162079 /* PSOperationsHealth */,
 				FD854FE11D2D8CC100162079 /* PSOperationsPassbook */,
 				1D9B43181B6A92ED008F7F18 /* PSOperationsTests */,
@@ -662,6 +709,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		775C7EF8205718C30091A21F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A39DCF722091C808009DF08E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -725,21 +779,17 @@
 				1D9B43581B6A934A008F7F18 /* NoCancelledDependencies.swift in Sources */,
 				1D9B43591B6A934A008F7F18 /* MutuallyExclusive.swift in Sources */,
 				55AE64DE1BC1DCF50097F4A5 /* UserNotificationCapability.swift in Sources */,
-				1D9B434F1B6A934A008F7F18 /* LocationOperation.swift in Sources */,
 				1D2DE6231F5600540080FF4F /* DispatchQueue+.swift in Sources */,
 				1D9B434C1B6A934A008F7F18 /* BlockOperation.swift in Sources */,
 				1D9B43631B6A934A008F7F18 /* Dictionary+Operations.swift in Sources */,
-				55AE64CD1BC1738D0097F4A5 /* LocationCapability-iOS.swift in Sources */,
 				55AE64DA1BC1C7430097F4A5 /* PushCapability-iOS.swift in Sources */,
 				1D9B43571B6A934A008F7F18 /* NegatedCondition.swift in Sources */,
 				1D9B434D1B6A934A008F7F18 /* GroupOperation.swift in Sources */,
 				1D9B43501B6A934A008F7F18 /* DelayOperation.swift in Sources */,
-				55AE64D21BC180570097F4A5 /* LocationCapability-tvOS.swift in Sources */,
 				1D9B43541B6A934A008F7F18 /* OperationErrors.swift in Sources */,
 				1D9B43561B6A934A008F7F18 /* SilentCondition.swift in Sources */,
 				1D9B43661B6A934A008F7F18 /* UIUserNotifications+Operations.swift in Sources */,
 				1D9B435A1B6A934A008F7F18 /* ReachabilityCondition.swift in Sources */,
-				55AE64D41BC180650097F4A5 /* LocationCapability-OSX.swift in Sources */,
 				1D9B43521B6A934A008F7F18 /* BlockObserver.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -760,6 +810,17 @@
 			buildActionMask = 2147483647;
 			files = (
 				775C7EFE2057191B0091A21F /* CalendarCapability.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A39DCF6C2091C808009DF08E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A39DCF7B2091C8B6009DF08E /* LocationCapability-OSX.swift in Sources */,
+				A39DCF7A2091C8B6009DF08E /* LocationCapability-tvOS.swift in Sources */,
+				A39DCF792091C8B6009DF08E /* LocationCapability-iOS.swift in Sources */,
+				A39DCF782091C8B6009DF08E /* LocationOperation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1076,6 +1137,57 @@
 			};
 			name = Release;
 		};
+		A39DCF742091C808009DF08E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "PSOperationsCalendar copy-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.pluralsight.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		A39DCF752091C808009DF08E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "PSOperationsCalendar copy-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.pluralsight.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator macosx";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
 		FD19C9EB1C440293005D0F07 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1277,6 +1389,15 @@
 			buildConfigurations = (
 				775C7EFA205718C30091A21F /* Debug */,
 				775C7EFB205718C30091A21F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A39DCF732091C808009DF08E /* Build configuration list for PBXNativeTarget "PSOperationsLocation" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A39DCF742091C808009DF08E /* Debug */,
+				A39DCF752091C808009DF08E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsLocation.xcscheme
+++ b/PSOperations.xcodeproj/xcshareddata/xcschemes/PSOperationsLocation.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0930"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A39DCF6B2091C808009DF08E"
+               BuildableName = "PSOperationsLocation.framework"
+               BlueprintName = "PSOperationsLocation"
+               ReferencedContainer = "container:PSOperations.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A39DCF6B2091C808009DF08E"
+            BuildableName = "PSOperationsLocation.framework"
+            BlueprintName = "PSOperationsLocation"
+            ReferencedContainer = "container:PSOperations.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A39DCF6B2091C808009DF08E"
+            BuildableName = "PSOperationsLocation.framework"
+            BlueprintName = "PSOperationsLocation"
+            ReferencedContainer = "container:PSOperations.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/PSOperationsLocation/LocationCapability-OSX.swift
+++ b/PSOperationsLocation/LocationCapability-OSX.swift
@@ -1,21 +1,22 @@
 //
-//  LocationCapability-tvOS.swift
+//  LocationCapability-OSX.swift
 //  PSOperations
 //
 //  Created by Dev Team on 10/4/15.
 //  Copyright © 2015 Pluralsight. All rights reserved.
 //
 
-#if os(tvOS)
+#if os(OSX)
 
 import Foundation
 import CoreLocation
+import PSOperations
 
 public struct Location: CapabilityType {
     public static let name = "Location"
 
     public init() { }
-
+    
     public func requestStatus(_ completion: @escaping (CapabilityStatus) -> Void) {
         guard CLLocationManager.locationServicesEnabled() else {
             completion(.notAvailable)
@@ -25,12 +26,16 @@ public struct Location: CapabilityType {
         let actual = CLLocationManager.authorizationStatus()
         
         switch actual {
-            case .notDetermined: completion(.notDetermined)
-            case .restricted: completion(.notAvailable)
-            case .denied: completion(.denied)
-            case .authorizedWhenInUse: completion(.authorized)
-            case .authorizedAlways:
-                fatalError(".Always should be unavailable on tvOS")
+        case .notDetermined:
+            completion(.notDetermined)
+        case .restricted:
+            completion(.notAvailable)
+        case .denied:
+            completion(.denied)
+        case .authorized:
+            completion(.authorized)
+        default:
+            completion(.authorized)
         }
     }
     
@@ -41,7 +46,7 @@ public struct Location: CapabilityType {
 
 private let Authorizer = LocationAuthorizer()
 
-private class LocationAuthorizer: NSObject, CLLocationManagerDelegate {
+fileprivate class LocationAuthorizer: NSObject, CLLocationManagerDelegate {
     
     private let manager = CLLocationManager()
     private var completion: ((CapabilityStatus) -> Void)?
@@ -57,28 +62,31 @@ private class LocationAuthorizer: NSObject, CLLocationManagerDelegate {
         }
         self.completion = completion
         
-        let key = "NSLocationWhenInUseUsageDescription"
-        manager.requestWhenInUseAuthorization()
+        let key = "NSLocationUsageDescription"
+        manager.startUpdatingLocation()
         
         // This is helpful when developing an app.
         assert(Bundle.main.object(forInfoDictionaryKey: key) != nil, "Requesting location permission requires the \(key) key in your Info.plist")
     }
     
+    
     @objc func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        if let completion = self.completion, manager == self.manager && status != .notDetermined {
+        if let completion = self.completion, manager == self.manager {
             self.completion = nil
             
             switch status {
-                case .authorizedWhenInUse:
-                    completion(.authorized)
-                case .denied:
-                    completion(.denied)
-                case .restricted:
-                    completion(.notAvailable)
-                case .authorizedAlways:
-                    fatalError(".Always should be unavailable on tvOS")
-                case .notDetermined:
-                    fatalError("Unreachable due to the if statement, but included to keep clang happy")
+            case .authorized:
+                completion(.authorized)
+            case .denied:
+                completion(.denied)
+            case .restricted:
+                completion(.notAvailable)
+            case .notDetermined:
+                self.completion = completion
+                manager.startUpdatingLocation()
+                manager.stopUpdatingLocation()
+            default:
+                completion(.authorized)
             }
         }
     }

--- a/PSOperationsLocation/LocationCapability-iOS.swift
+++ b/PSOperationsLocation/LocationCapability-iOS.swift
@@ -10,6 +10,7 @@
 
 import Foundation
 import CoreLocation
+import PSOperations
 
 public enum Location: CapabilityType {
     public static let name = "Location"

--- a/PSOperationsLocation/LocationCapability-tvOS.swift
+++ b/PSOperationsLocation/LocationCapability-tvOS.swift
@@ -1,21 +1,22 @@
 //
-//  LocationCapability-OSX.swift
+//  LocationCapability-tvOS.swift
 //  PSOperations
 //
 //  Created by Dev Team on 10/4/15.
 //  Copyright © 2015 Pluralsight. All rights reserved.
 //
 
-#if os(OSX)
+#if os(tvOS)
 
 import Foundation
 import CoreLocation
+import PSOperations
 
 public struct Location: CapabilityType {
     public static let name = "Location"
 
     public init() { }
-    
+
     public func requestStatus(_ completion: @escaping (CapabilityStatus) -> Void) {
         guard CLLocationManager.locationServicesEnabled() else {
             completion(.notAvailable)
@@ -25,16 +26,12 @@ public struct Location: CapabilityType {
         let actual = CLLocationManager.authorizationStatus()
         
         switch actual {
-        case .notDetermined:
-            completion(.notDetermined)
-        case .restricted:
-            completion(.notAvailable)
-        case .denied:
-            completion(.denied)
-        case .authorized:
-            completion(.authorized)
-        default:
-            completion(.authorized)
+            case .notDetermined: completion(.notDetermined)
+            case .restricted: completion(.notAvailable)
+            case .denied: completion(.denied)
+            case .authorizedWhenInUse: completion(.authorized)
+            case .authorizedAlways:
+                fatalError(".Always should be unavailable on tvOS")
         }
     }
     
@@ -45,7 +42,7 @@ public struct Location: CapabilityType {
 
 private let Authorizer = LocationAuthorizer()
 
-fileprivate class LocationAuthorizer: NSObject, CLLocationManagerDelegate {
+private class LocationAuthorizer: NSObject, CLLocationManagerDelegate {
     
     private let manager = CLLocationManager()
     private var completion: ((CapabilityStatus) -> Void)?
@@ -61,31 +58,28 @@ fileprivate class LocationAuthorizer: NSObject, CLLocationManagerDelegate {
         }
         self.completion = completion
         
-        let key = "NSLocationUsageDescription"
-        manager.startUpdatingLocation()
+        let key = "NSLocationWhenInUseUsageDescription"
+        manager.requestWhenInUseAuthorization()
         
         // This is helpful when developing an app.
         assert(Bundle.main.object(forInfoDictionaryKey: key) != nil, "Requesting location permission requires the \(key) key in your Info.plist")
     }
     
-    
     @objc func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        if let completion = self.completion, manager == self.manager {
+        if let completion = self.completion, manager == self.manager && status != .notDetermined {
             self.completion = nil
             
             switch status {
-            case .authorized:
-                completion(.authorized)
-            case .denied:
-                completion(.denied)
-            case .restricted:
-                completion(.notAvailable)
-            case .notDetermined:
-                self.completion = completion
-                manager.startUpdatingLocation()
-                manager.stopUpdatingLocation()
-            default:
-                completion(.authorized)
+                case .authorizedWhenInUse:
+                    completion(.authorized)
+                case .denied:
+                    completion(.denied)
+                case .restricted:
+                    completion(.notAvailable)
+                case .authorizedAlways:
+                    fatalError(".Always should be unavailable on tvOS")
+                case .notDetermined:
+                    fatalError("Unreachable due to the if statement, but included to keep clang happy")
             }
         }
     }

--- a/PSOperationsLocation/LocationOperation.swift
+++ b/PSOperationsLocation/LocationOperation.swift
@@ -10,6 +10,7 @@ Shows how to retrieve the user's location with an operation.
 
 import Foundation
 import CoreLocation
+import PSOperations
 
 /**
  `LocationOperation` is an `Operation` subclass to do a "one-shot" request to

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ Core functionality, including only the Calendar capability:
 pod 'PSOperations/Calendar', '~> 4.0'
 ```
 
+Core functionality, including only the Location capability and operation:
+```ruby
+pod 'PSOperations/Location', '~> 4.0'
+```
+
 ### Carthage
 [Carthage](https://github.com/Carthage/Carthage) is a decentralized dependency manager that builds your dependencies and provides you with binary frameworks.
 
@@ -96,7 +101,7 @@ To integrate PSOperations into your Xcode project using Carthage, specify it in 
 github "pluralsight/PSOperations"
 ```
 
-Run `carthage` to build the framework and drag the built `PSOperations.framework` into your Xcode project. Optionally you can add `PSOperationsHealth.framework`, `PSOperationsPassbook.framework` and `PSOperationsCalendar.framework`
+Run `carthage` to build the framework and drag the built `PSOperations.framework` into your Xcode project. Optionally you can add `PSOperationsHealth.framework`, `PSOperationsPassbook.framework`, `PSOperationsCalendar.framework`  and `PSOperationsLocation.framework`
 
 ## Getting started
 
@@ -105,15 +110,16 @@ Don't forget to import!
 import PSOperations
 ```
 
-If you are using the HealthCapability, PassbookCapability or CalendarCapability you'll need to import them separately:
+If you are using the HealthCapability, PassbookCapability, CalendarCapability, LocationCapability or LocationOperation you'll need to import them separately:
 
 ```
 import PSOperationsHealth
 import PSOperationsPassbook
 import PSOperationsCalendar
+import PSOperationsLocation
 ```
 
-These features need to be in a separate framework otherwise they may cause App Store review rejection for importing `HealthKit`, `PassKit` or `EventKit` but not actually using them.
+These features need to be in a separate framework otherwise they may cause App Store review rejection for importing `HealthKit`, `PassKit`, `EventKit` or `CoreLocation` but not actually using them.
 
 #### Create a Queue
 The OperationQueue is the heartbeat and is a subclass of NSOperationQueue:


### PR DESCRIPTION
When trying to submit an App depending on PSOperations/Core to the AppStore, Apple is complaining about missing Info.plist keys "NSLocationAlwaysUsageDescription" and "NSLocationWhenInUseUsageDescription". 
This comes from the use of CLLocationManager#requestAlwaysAuthorization  and CLLocationManager#requestWhenInUseAuthorization (see [apple doc](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW18)).
This commit moves files depending on CoreLocation to a dedicated Pod "PSOperations/Location".
[Related issue](https://github.com/pluralsight/PSOperations/issues/109)