### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS
+.DS_Store
+
 # Xcode
 #
 build/
@@ -31,4 +34,8 @@ DerivedData
 # Carthage/Checkouts
 
 Carthage/Build
-.DS_Store
+
+# Swift Package Manager
+.build/
+.swiftpm/
+Packages/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,54 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "PSOperations",
+    platforms: [
+        .iOS(.v8),
+        .macOS(.v10_11),
+        .tvOS(.v9),
+    ],
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "PSOperations",
+            targets: ["PSOperations"]),
+        .library(
+            name: "PSOperationsCalendar",
+            targets: ["PSOperationsCalendar"]),
+        .library(
+            name: "PSOperationsLocation",
+            targets: ["PSOperationsLocation"]),
+        .library(
+            name: "PSOperationsHealth",
+            targets: ["PSOperationsHealth"]),
+        .library(
+            name: "PSOperationsPassbook",
+            targets: ["PSOperationsPassbook"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(name: "PSOperations",
+                path: "PSOperations",
+                exclude: ["Info.plist", "PSOperations.h"]),
+        .target(name: "PSOperationsCalendar",
+                dependencies: ["PSOperations"],
+                path: "PSOperationsCalendar"),
+        .target(name: "PSOperationsLocation",
+                dependencies: ["PSOperations"],
+                path: "PSOperationsLocation"),
+        .target(name: "PSOperationsHealth",
+                dependencies: ["PSOperations"],
+                path: "PSOperationsHealth"),
+        .target(name: "PSOperationsPassbook",
+                dependencies: ["PSOperations"],
+                path: "PSOperationsPassbook"),
+        .testTarget(name: "PSOperationsTests",
+                    dependencies: ["PSOperations"],
+                    path: "PSOperationsTests",
+                    exclude: ["Info.plist"]),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is an adaptation of the sample code provided in the [Advanced NSOperations]
  - iOS 8.0
  - tvOS 9.0
  - watchOS (undefined deployment target)
- - macOS (undefined deployment target)
+ - macOS 10.11
  - Extension friendly
  - Tests only run against iOS 9 (latest) and tvOS 9 (latest)
 
@@ -31,6 +31,16 @@ public typealias PSBlockOperation = BlockOperation
 
 ## Installation
 PSOperations supports multiple methods for installing the library in a project.
+
+### Swift Package Manager
+
+The [Swift Package Manager](https://swift.org/package-manager) (SPM) is Swift's own dependency management as of Swift 3.0. Xcode 11 gained native support for SPM and allows to add dependencies to apps from within Xcode.
+
+PSOperations can be added either via Xcode 11+, or by adding the following dependency to your Package.swift:
+
+```swift
+.package(url: "https://github.com/pluralsight/PSOperations.git", from: "5.0.2"),
+```
 
 ### CocoaPods
 [CocoaPods](http://cocoapods.org) is a dependency manager for Objective-C, which automates and simplifies the process of using 3rd-party libraries like PSOperations in your projects.


### PR DESCRIPTION
This adds SPM support for PSOperations.

It's currently a rather "basic" support as in new "Xcode-specific" files have to be added manually to the list of ignored files. Also, certain targets in the Xcode project have not been added to Package.swift (like the AppForTests and MacTests), because they're not needed in SPM.

Resolves #124.