### PR TITLE
Fix Package.swift tools version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,5 @@
-// swiftlint:disable:next file_header
 // swift-tools-version:5.3
+// swiftlint:disable:previous file_header
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -1,5 +1,5 @@
-// swiftlint:disable:next file_header
 // swift-tools-version:5.1
+// swiftlint:disable:previous file_header
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package@swift-5.2.swift
+++ b/Package@swift-5.2.swift
@@ -1,5 +1,5 @@
-// swiftlint:disable:next file_header
 // swift-tools-version:5.2
+// swiftlint:disable:previous file_header
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
The first line in a Package.swift needs to be the tools version. Otherwise SPM will reject it.
Currently, versions (tags) as of 5.0.4 (5.0.4, 5.0.5, 5.0.6) cannot be used with Swift Package Manager due to this.