### PR TITLE
[Fix] Swift package Manager definition  for swift-tools >= 5.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,6 @@
-// swiftlint:disable:next file_header
 // swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
+// swiftlint:disable:next file_header
 
 import PackageDescription
 

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -1,6 +1,6 @@
-// swiftlint:disable:next file_header
 // swift-tools-version:5.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
+// swiftlint:disable:next file_header
 
 import PackageDescription
 

--- a/Package@swift-5.2.swift
+++ b/Package@swift-5.2.swift
@@ -1,6 +1,6 @@
-// swiftlint:disable:next file_header
 // swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
+// swiftlint:disable:next file_header
 
 import PackageDescription
 


### PR DESCRIPTION
Latest code shows this error when importing the swift package:
"the Swift Tools version specification is probably missing a version specifier"

The problem seems to be that swift-tools 5.5 expects the swift-tool-version header at the beginning of the file.
Moving the swiftlint directive below the package definitions solves the issue.
